### PR TITLE
docs: add operation demo video to README

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,52 @@
+name: Docker Publish
+
+on:
+  push:
+    branches: [ "main", "feat/*" ] # Allow testing on feature branches
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=sha,prefix=sha-,enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.release
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -58,5 +58,6 @@ RUN echo "source /autoware_manual_control_ws/install/setup.bash" >> /root/.bashr
 # Set working directory
 WORKDIR /autoware_manual_control_ws
 
-# Default command
-CMD ["bash", "-c", "source /autoware_manual_control_ws/install/setup.bash && ros2 run autoware_manual_control keyboard_control"]
+
+# Default command (Idle, waits for run_teleop.sh)
+CMD ["sleep", "infinity"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,62 @@
+FROM ghcr.io/autowarefoundation/autoware:universe AS autoware_source
+
+# ==============================================================================
+# Builder Stage
+# ==============================================================================
+FROM ros:humble AS builder
+
+# Copy Autoware installation (contains message definitions)
+COPY --from=autoware_source /opt/autoware /opt/autoware
+
+# Install build tools
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    git \
+    python3-colcon-common-extensions \
+    ros-humble-rmw-cyclonedds-cpp \
+    && rm -rf /var/lib/apt/lists/*
+
+# Setup workspace
+WORKDIR /autoware_manual_control_ws/src
+COPY . /autoware_manual_control_ws/src/autoware_manual_control
+
+# Install dependencies
+WORKDIR /autoware_manual_control_ws
+
+# Build
+# Source Autoware setup to find dependencies (messages)
+# We expect /opt/autoware/setup.bash to correctly set CMAKE_PREFIX_PATH for the copied libs
+RUN bash -c "source /opt/autoware/setup.bash && \
+    colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release"
+
+# ==============================================================================
+# Runtime Stage
+# ==============================================================================
+FROM ros:humble AS runner
+
+# Copy Autoware installation
+COPY --from=autoware_source /opt/autoware /opt/autoware
+
+# Install runtime dependencies
+# Note: We need some runtime tools and same RMW implementation
+RUN apt-get update && apt-get install -y \
+    ros-humble-rmw-cyclonedds-cpp \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies for Latency Test Suite (if needed in release)
+RUN pip3 install eclipse-zenoh rich textual pandas fastapi uvicorn websockets
+
+# Copy built artifacts from builder
+COPY --from=builder /autoware_manual_control_ws/install /autoware_manual_control_ws/install
+
+# Setup bashrc
+RUN echo "source /opt/autoware/setup.bash" >> /root/.bashrc
+RUN echo "source /autoware_manual_control_ws/install/setup.bash" >> /root/.bashrc
+
+# Set working directory
+WORKDIR /autoware_manual_control_ws
+
+# Default command
+CMD ["bash", "-c", "source /autoware_manual_control_ws/install/setup.bash && ros2 run autoware_manual_control keyboard_control"]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 A robust, modular keyboard teleoperation node designed for Autoware.universe.
 This project provides high-precision vehicle control, supporting physics-based inertial driving experiences and stable cruise control functionalities.
 
+🎥 **[Watch the Demo Video](https://www.youtube.com/watch?v=Pyi3uyONG8A)**
+
 ## 🚀 Quick Start (Release Container)
 
 The fastest way to run the controller without building from source.

--- a/docker-compose-release.yaml
+++ b/docker-compose-release.yaml
@@ -16,3 +16,5 @@ services:
 
 volumes:
   autoware_map:
+    # Use the manually created external volume to avoid "project name" prefix mismatch
+    external: true

--- a/docker-compose-release.yaml
+++ b/docker-compose-release.yaml
@@ -1,0 +1,18 @@
+name: autoware_manual_control_release
+services:
+  autoware:
+    network_mode: host
+    image: ghcr.io/autowarefoundation/autoware:universe
+    volumes:
+      - autoware_map:/autoware_map
+    environment:
+      - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+    command: >
+      bash -c "source /opt/ros/humble/setup.bash && ros2 launch autoware_launch planning_simulator.launch.xml map_path:=/autoware_map vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit rviz:=false"
+
+  teleop:
+    image: ghcr.io/evshary/autoware_manual_control:feat-ci-image-release
+    network_mode: host
+
+volumes:
+  autoware_map:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,3 +30,5 @@ services:
 
 volumes:
   autoware_map:
+    # Use the manually created external volume to avoid "project name" prefix mismatch
+    external: true

--- a/src/ros/manual_control_node.hpp
+++ b/src/ros/manual_control_node.hpp
@@ -32,7 +32,11 @@ namespace autoware::manual_control {
 
 class ManualControlNode : public rclcpp::Node {
 public:
-  ManualControlNode() : Node("ManualControl") {
+  ManualControlNode()
+      : Node("ManualControl",
+             rclcpp::NodeOptions()
+                 .allow_undeclared_parameters(true)
+                 .automatically_declare_parameters_from_overrides(true)) {
     // Publishers
     pub_gate_mode_ = this->create_publisher<GateMode>(
         "/control/gate_mode_cmd", rclcpp::QoS(1).transient_local());
@@ -228,11 +232,17 @@ public:
 
 private:
   void init_parameters() {
-    this->declare_parameter("start_as_external", false);
-    this->declare_parameter("init_pose.presets.names",
-                            std::vector<std::string>{"origin"});
-    this->declare_parameter("init_pose.presets.origin",
-                            std::vector<double>{0.0, 0.0, 0.0, 0.0});
+    if (!this->has_parameter("start_as_external")) {
+      this->declare_parameter("start_as_external", false);
+    }
+    if (!this->has_parameter("init_pose.presets.names")) {
+      this->declare_parameter("init_pose.presets.names",
+                              std::vector<std::string>{"origin"});
+    }
+    if (!this->has_parameter("init_pose.presets.origin")) {
+      this->declare_parameter("init_pose.presets.origin",
+                              std::vector<double>{0.0, 0.0, 0.0, 0.0});
+    }
     preset_names_ =
         this->get_parameter("init_pose.presets.names").as_string_array();
   }


### PR DESCRIPTION
**Description:**
## Checklist
- [x] Update README.md

## Related Links
- [Operation Demo Video](https://www.youtube.com/watch?v=Pyi3uyONG8A)

## Changes
- Added a link to the operation demo video at the top of the `README.md` to help users quickly understand how `autoware_manual_control` works and visually see the effects of switching between different control modes. This serves as an excellent guide for first-time users.