### PR TITLE
docs: add operation demo video to README and ignore docs in CI

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -53,6 +53,6 @@ jobs:
         with:
           context: .
           file: Dockerfile.release
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,8 +4,14 @@ on:
   push:
     branches: [ "main", "feat/*" ] # Allow testing on feature branches
     tags: [ 'v*.*.*' ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
   workflow_dispatch:
 
 env:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 A robust, modular keyboard teleoperation node designed for Autoware.universe.
 This project provides high-precision vehicle control, supporting physics-based inertial driving experiences and stable cruise control functionalities.
 
+🎥 **[Watch the Demo Video](https://www.youtube.com/watch?v=Pyi3uyONG8A)**
+
 ## 🚀 Quick Start (Release Container)
 
 The fastest way to run the controller without building from source.


### PR DESCRIPTION
**Description:**
## Checklist
- [x] Update README.md
- [x] Update CI/CD workflow to ignore documentation changes

## Related Links
- [Operation Demo Video](https://www.youtube.com/watch?v=Pyi3uyONG8A)

## Changes
- Added a link to the operation demo video at the top of the `README.md` to help users quickly understand how `autoware_manual_control` works and visually see the effects of switching between different control modes. This serves as an excellent guide for first-time users.
- Updated `.github/workflows/docker-publish.yml` to ignore pushes and pull requests that only modify markdown files (`**.md`) or the `docs/**` directory, preventing unnecessary CI/CD builds.