### PR TITLE
feat: rewrite as Zenoh-driven teleop for FMS with Autoware 1.5+ compat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,35 +7,62 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
-# uncomment the following section in order to fill in
-# further dependencies manually.
-# find_package(<dependency> REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(tier4_control_msgs)
 find_package(tier4_external_api_msgs)
 find_package(autoware_control_msgs)
 find_package(autoware_vehicle_msgs)
+find_package(autoware_adapi_v1_msgs)
+find_package(geometry_msgs)
 
+set(COMMON_ROS_DEPS rclcpp
+                    tier4_control_msgs
+                    tier4_external_api_msgs
+                    autoware_control_msgs
+                    autoware_vehicle_msgs
+                    autoware_adapi_v1_msgs
+                    geometry_msgs)
+
+# keyboard_control: standalone, always built.
 add_executable(keyboard_control src/keyboard_control.cpp src/core/drive_mode_factory.cpp)
 target_include_directories(keyboard_control PRIVATE src)
-ament_target_dependencies(keyboard_control rclcpp
-                                           tier4_control_msgs
-                                           tier4_external_api_msgs
-                                           autoware_control_msgs
-                                           autoware_vehicle_msgs)
+ament_target_dependencies(keyboard_control ${COMMON_ROS_DEPS})
 
-install(TARGETS
-  keyboard_control
-  DESTINATION lib/${PROJECT_NAME})
+install(TARGETS keyboard_control DESTINATION lib/${PROJECT_NAME})
+
+# remote_control: optional, built only when zenoh-cpp + nlohmann_json are found.
+find_package(nlohmann_json QUIET)
+
+set(ZENOH_VENDOR_PREFIX
+    "$ENV{ZENOH_VENDOR_PREFIX}"
+    CACHE PATH "Path to zenoh vendor from rmw_zenoh build")
+if(ZENOH_VENDOR_PREFIX)
+    find_package(zenohc   QUIET PATHS "${ZENOH_VENDOR_PREFIX}/lib/cmake" NO_DEFAULT_PATH)
+    find_package(zenohcxx QUIET PATHS "${ZENOH_VENDOR_PREFIX}/lib/cmake" NO_DEFAULT_PATH)
+endif()
+if(NOT zenohc_FOUND)
+    find_package(zenohc QUIET)
+endif()
+if(NOT zenohcxx_FOUND)
+    find_package(zenohcxx QUIET)
+endif()
+
+if(zenohcxx_FOUND AND nlohmann_json_FOUND)
+    message(STATUS "[autoware_manual_control] Building remote_control (zenoh-cpp found)")
+    add_executable(remote_control src/remote_control.cpp src/core/drive_mode_factory.cpp)
+    target_include_directories(remote_control PRIVATE src)
+    ament_target_dependencies(remote_control ${COMMON_ROS_DEPS})
+    target_link_libraries(remote_control
+        nlohmann_json::nlohmann_json
+        zenohcxx::zenohc)
+    install(TARGETS remote_control DESTINATION lib/${PROJECT_NAME})
+else()
+    message(WARNING "[autoware_manual_control] Skipping remote_control — zenoh-cpp or nlohmann_json not found. "
+                    "Set ZENOH_VENDOR_PREFIX env var or install zenohcxx system-wide.")
+endif()
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
-  # the following line skips the linter which checks for copyrights
-  # uncomment the line when a copyright and license is not present in all source files
-  #set(ament_cmake_copyright_FOUND TRUE)
-  # the following line skips cpplint (only works in a git repo)
-  # uncomment the line when this package is not in a git repo
-  #set(ament_cmake_cpplint_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 endif()
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,37 +2,39 @@ FROM ghcr.io/autowarefoundation/autoware:universe AS autoware_source
 
 FROM ros:humble
 
-# Copy Autoware installation (contains message definitions)
+# Autoware message definitions (copied from the universe image).
 COPY --from=autoware_source /opt/autoware /opt/autoware
 
-# Install build tools
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    cmake \
-    git \
-    python3-colcon-common-extensions \
-    ros-humble-rmw-cyclonedds-cpp \
+# Build toolchain + deps. geographic_msgs / unique-identifier-msgs back
+# autoware_adapi_v1_msgs; nlohmann-json + zenoh-cpp-vendor build remote_control.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        git \
+        python3-colcon-common-extensions \
+        python3-pip \
+        ros-humble-rmw-cyclonedds-cpp \
+        ros-humble-geographic-msgs \
+        ros-humble-unique-identifier-msgs \
+        ros-humble-zenoh-cpp-vendor \
+        nlohmann-json3-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Setup workspace
-WORKDIR /autoware_manual_control_ws/src
+# Python deps for the latency test suite / tooling.
+RUN pip3 install --no-cache-dir \
+        eclipse-zenoh rich textual pandas fastapi uvicorn websockets
+
+# Workspace.
+WORKDIR /autoware_manual_control_ws
 COPY . /autoware_manual_control_ws/src/autoware_manual_control
 
-# Install dependencies
-WORKDIR /autoware_manual_control_ws
-
-# Build
-# Source Autoware setup to find dependencies (messages)
-# We expect /opt/autoware/setup.bash to correctly set CMAKE_PREFIX_PATH for the copied libs
+# ZENOH_VENDOR_PREFIX lets CMake locate the zenoh-cpp vendor package.
+ENV ZENOH_VENDOR_PREFIX=/opt/ros/humble/opt/zenoh_cpp_vendor
 RUN bash -c "source /opt/autoware/setup.bash && \
-    colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release"
+             source /opt/ros/humble/setup.bash && \
+             colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release"
 
-# Install Python dependencies for Latency Test Suite
-RUN apt-get update && apt-get install -y python3-pip && rm -rf /var/lib/apt/lists/*
-RUN pip3 install eclipse-zenoh rich textual pandas fastapi uvicorn websockets
-
-# Setup bashrc
-RUN echo "source /autoware_manual_control_ws/install/setup.bash" >> /root/.bashrc
-RUN echo "source /autoware_manual_control_ws/install/setup.bash" >> /etc/bash.bashrc
+RUN echo "source /autoware_manual_control_ws/install/setup.bash" \
+        | tee -a /root/.bashrc /etc/bash.bashrc > /dev/null
 
 CMD ["sleep", "infinity"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,6 +17,10 @@ services:
       - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
       - REMOTE_PASSWORD=o
       - USE_SIM_TIME=false
+    # TigerVNC inside the container needs to resolve the host's hostname; with
+    # network_mode: host the container inherits it but has no /etc/hosts entry.
+    extra_hosts:
+      - "${HOSTNAME:-localhost}:127.0.0.1"
 
   teleop:
     network_mode: host

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
   <depend>tier4_external_api_msgs</depend>
   <depend>autoware_control_msgs</depend>
   <depend>autoware_vehicle_msgs</depend>
+  <depend>autoware_adapi_v1_msgs</depend>
   <depend>geometry_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/run_containers.sh
+++ b/run_containers.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Ensure HOSTNAME is exported so docker-compose can expand ${HOSTNAME} in
+# extra_hosts (needed by the visualizer service).
+export HOSTNAME="${HOSTNAME:-$(hostname)}"
+
 # Color definitions
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'

--- a/src/bridge/zenoh/zenoh_input.hpp
+++ b/src/bridge/zenoh/zenoh_input.hpp
@@ -1,0 +1,212 @@
+#ifndef TELEOP_ZENOH_INPUT_HPP
+#define TELEOP_ZENOH_INPUT_HPP
+
+// Network InputSource: subscribes the intent key and turns each message into
+// an InputState. Network-specific safety lives here:
+//  - Deadman: with no intent within arrival_timeout_s, update() returns a
+//    safe InputState (brake) so the loop stops without a special case.
+//  - Discrete actions travel as monotonic counters and are edge-detected
+//    here, so a dropped or duplicated packet is harmless.
+//  - active_client_id is recorded for telemetry, not used to arbitrate.
+
+#include <zenoh.hxx>
+
+#include <nlohmann/json.hpp>
+
+#include "common/types.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <memory>
+#include <mutex>
+#include <string>
+
+namespace autoware::manual_control {
+
+struct ZenohInputConfig {
+  std::string intent_key = "manual_control/v1/intent";
+  float arrival_timeout_s = 0.5f; // no packet for this long -> safe stop
+};
+
+class ZenohInput {
+public:
+  ZenohInput(std::shared_ptr<zenoh::Session> session,
+             const ZenohInputConfig &cfg)
+      : cfg_(cfg), session_(std::move(session)) {
+    last_arrival_ = std::chrono::steady_clock::now();
+    subscriber_ = std::make_unique<zenoh::Subscriber<void>>(
+        session_->declare_subscriber(
+            zenoh::KeyExpr(cfg_.intent_key),
+            [this](zenoh::Sample &sample) { on_intent(sample); }, []() {}));
+  }
+
+  // InputSource contract.
+  InputState update() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto now = std::chrono::steady_clock::now();
+
+    const bool fresh =
+        have_intent_ && secs(now - last_arrival_) <= cfg_.arrival_timeout_s;
+    watchdog_tripped_.store(!fresh);
+
+    if (!fresh)
+      return safe_state(); // deadman: full brake, no events
+
+    InputState s;
+    s.throttle = clamp01(latest_.throttle);
+    s.brake = clamp01(latest_.brake);
+    s.steer_dir = (latest_.steer > 0.0) ? 1 : (latest_.steer < 0.0 ? -1 : 0);
+
+    // gear level -> one-tick shift trigger when the desired gear changes
+    if (latest_.gear != applied_gear_) {
+      s.shift_drive = (latest_.gear == Gear::DRIVE);
+      s.shift_reverse = (latest_.gear == Gear::REVERSE);
+      s.shift_park = (latest_.gear == Gear::PARK);
+      applied_gear_ = latest_.gear;
+    }
+
+    // monotonic counters -> one-tick edge
+    s.emergency_stop = advance(applied_estop_, latest_.estop);
+    s.switch_mode = advance(applied_mode_cycle_, latest_.mode_cycle);
+    s.toggle_auto = advance(applied_toggle_auto_, latest_.toggle_auto);
+    s.reset_pose = advance(applied_reset_pose_, latest_.reset_pose);
+    // quit: never set for a remote operator.
+    return s;
+  }
+
+  // Telemetry accessors.
+  std::string active_client_id() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return latest_.client_id;
+  }
+  bool watchdog_tripped() const { return watchdog_tripped_.load(); }
+
+private:
+  struct Intent {
+    float throttle = 0.0f;
+    float brake = 0.0f;
+    double steer = 0.0;
+    Gear gear = Gear::PARK;
+    int64_t estop = 0;
+    int64_t mode_cycle = 0;
+    int64_t toggle_auto = 0;
+    int64_t reset_pose = 0;
+    std::string client_id;
+  };
+
+  void on_intent(zenoh::Sample &sample) {
+    nlohmann::json j;
+    try {
+      j = nlohmann::json::parse(sample.get_payload().as_string());
+    } catch (...) {
+      warn_once("unparseable JSON");
+      return;
+    }
+
+    // client_id is the only required field (operator identity); missing or
+    // wrong-typed -> reject the whole message so the watchdog catches it.
+    if (!j.contains("client_id") || !j["client_id"].is_string()) {
+      warn_once("missing or invalid client_id");
+      return;
+    }
+    // Optional fields: if present, must be the expected type.
+    auto num_ok = [&](const char *k) {
+      return !j.contains(k) || j[k].is_number();
+    };
+    if (!num_ok("throttle") || !num_ok("brake") || !num_ok("steer") ||
+        !num_ok("estop") || !num_ok("mode_cycle") ||
+        !num_ok("toggle_auto") || !num_ok("reset_pose")) {
+      warn_once("non-numeric value in numeric field");
+      return;
+    }
+    if (j.contains("gear")) {
+      if (!j["gear"].is_string()) {
+        warn_once("non-string gear");
+        return;
+      }
+      const std::string &g = j["gear"].get_ref<const std::string &>();
+      if (g != "DRIVE" && g != "REVERSE" && g != "PARK") {
+        warn_once("unknown gear value");
+        return;
+      }
+    }
+
+    Intent in;
+    in.throttle = j.value("throttle", 0.0);
+    in.brake = j.value("brake", 0.0);
+    in.steer = j.value("steer", 0.0);
+    in.gear = gear_from(j.value("gear", std::string("PARK")));
+    in.estop = j.value("estop", int64_t{0});
+    in.mode_cycle = j.value("mode_cycle", int64_t{0});
+    in.toggle_auto = j.value("toggle_auto", int64_t{0});
+    in.reset_pose = j.value("reset_pose", int64_t{0});
+    in.client_id = j["client_id"].get<std::string>();
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    latest_ = in;
+    have_intent_ = true;
+    last_arrival_ = std::chrono::steady_clock::now();
+  }
+
+  static void warn_once(const char *reason) {
+    static bool warned = false;
+    if (!warned) {
+      warned = true;
+      std::fprintf(stderr,
+                   "[ZenohInput] rejecting malformed intent (%s); "
+                   "will not warn again\n",
+                   reason);
+    }
+  }
+
+  static float secs(std::chrono::steady_clock::duration d) {
+    return std::chrono::duration<float>(d).count();
+  }
+  static float clamp01(float v) { return v < 0.0f ? 0.0f : (v > 1.0f ? 1.0f : v); }
+  static Gear gear_from(const std::string &g) {
+    if (g == "DRIVE")
+      return Gear::DRIVE;
+    if (g == "REVERSE")
+      return Gear::REVERSE;
+    return Gear::PARK;
+  }
+  // Fire once per counter increment: tolerant of loss (catches up) and of
+  // duplicates (never re-fires).
+  static bool advance(int64_t &applied, int64_t wire) {
+    if (wire > applied) {
+      applied = wire;
+      return true;
+    }
+    return false;
+  }
+  // Safe intent returned whenever there is no fresh real intent.
+  static InputState safe_state() {
+    InputState s; // defaults: throttle 0, steer 0, all events false
+    s.brake = 1.0f;
+    return s;
+  }
+
+  ZenohInputConfig cfg_;
+  std::shared_ptr<zenoh::Session> session_;
+  std::unique_ptr<zenoh::Subscriber<void>> subscriber_;
+
+  mutable std::mutex mutex_;
+  Intent latest_;
+  bool have_intent_ = false;
+  std::chrono::steady_clock::time_point last_arrival_;
+
+  // Edge-detection state.
+  Gear applied_gear_ = Gear::PARK;
+  int64_t applied_estop_ = 0;
+  int64_t applied_mode_cycle_ = 0;
+  int64_t applied_toggle_auto_ = 0;
+  int64_t applied_reset_pose_ = 0;
+
+  std::atomic<bool> watchdog_tripped_{true};
+};
+
+} // namespace autoware::manual_control
+
+#endif // TELEOP_ZENOH_INPUT_HPP

--- a/src/bridge/zenoh/zenoh_input.hpp
+++ b/src/bridge/zenoh/zenoh_input.hpp
@@ -142,7 +142,7 @@ private:
     in.mode_cycle = j.value("mode_cycle", int64_t{0});
     in.toggle_auto = j.value("toggle_auto", int64_t{0});
     in.reset_pose = j.value("reset_pose", int64_t{0});
-    in.client_id = j["client_id"].get<std::string>();
+    in.client_id = j.value("client_id", std::string{});
 
     std::lock_guard<std::mutex> lock(mutex_);
     latest_ = in;

--- a/src/bridge/zenoh/zenoh_telemetry.hpp
+++ b/src/bridge/zenoh/zenoh_telemetry.hpp
@@ -1,0 +1,86 @@
+#ifndef TELEOP_ZENOH_TELEMETRY_HPP
+#define TELEOP_ZENOH_TELEMETRY_HPP
+
+// Network TelemetrySink: serializes each Telemetry snapshot to JSON on the
+// vehicle's telemetry key. The network-specific fields come from ZenohInput.
+
+#include <zenoh.hxx>
+
+#include <nlohmann/json.hpp>
+
+#include "bridge/zenoh/zenoh_input.hpp"
+#include "common/types.hpp"
+#include "core/telemetry.hpp"
+
+#include <memory>
+#include <string>
+
+namespace autoware::manual_control {
+
+class ZenohTelemetry {
+public:
+  ZenohTelemetry(std::shared_ptr<zenoh::Session> session,
+                 const ZenohInput &input,
+                 const std::string &telemetry_key)
+      : session_(std::move(session)), input_(input) {
+    pub_ = std::make_unique<zenoh::Publisher>(
+        session_->declare_publisher(telemetry_key));
+  }
+
+  // TelemetrySink contract.
+  void publish(const Telemetry &t) {
+    nlohmann::json j;
+    j["mode"] = t.mode;
+    j["mode_status"] = t.mode_status;
+    j["velocity"] = t.vehicle.velocity;
+    j["gear"] = gear_str(t.vehicle.gear);
+    j["steer_angle"] = t.vehicle.steer_angle;
+    j["target_velocity"] = t.command.velocity;
+    j["target_acceleration"] = t.command.acceleration;
+    j["target_steer"] = t.command.steer_angle;
+    j["shift_state"] = shift_state_str(t.shift_state);
+    j["pending_gear"] =
+        (t.shift_state != ShiftState::IDLE) ? gear_str(t.pending_gear) : "";
+    j["info"] = t.info;
+    // from ZenohInput
+    j["active_client_id"] = input_.active_client_id();
+    j["watchdog_tripped"] = input_.watchdog_tripped();
+    pub_->put(zenoh::Bytes(j.dump()));
+  }
+
+private:
+  static std::string gear_str(Gear g) {
+    switch (g) {
+    case Gear::DRIVE:
+      return "DRIVE";
+    case Gear::REVERSE:
+      return "REVERSE";
+    case Gear::PARK:
+      return "PARK";
+    case Gear::LOW:
+      return "LOW";
+    case Gear::NEUTRAL:
+      return "NEUTRAL";
+    default:
+      return "NONE";
+    }
+  }
+  static std::string shift_state_str(ShiftState s) {
+    switch (s) {
+    case ShiftState::STOPPING:
+      return "STOPPING";
+    case ShiftState::SHIFTING:
+      return "SHIFTING";
+    default:
+      return "IDLE";
+    }
+  }
+
+  std::shared_ptr<zenoh::Session> session_;
+  const ZenohInput &input_;
+  std::unique_ptr<zenoh::Publisher> pub_;
+};
+
+} // namespace autoware::manual_control
+
+#endif // TELEOP_ZENOH_TELEMETRY_HPP

--- a/src/bridge/zenoh/zenoh_telemetry.hpp
+++ b/src/bridge/zenoh/zenoh_telemetry.hpp
@@ -12,6 +12,7 @@
 #include "common/types.hpp"
 #include "core/telemetry.hpp"
 
+#include <chrono>
 #include <memory>
 #include <string>
 
@@ -45,6 +46,11 @@ public:
     // from ZenohInput
     j["active_client_id"] = input_.active_client_id();
     j["watchdog_tripped"] = input_.watchdog_tripped();
+    // Wall-clock ms at publish time — lets the UI compute one-way latency
+    // (Date.now() - timestamp) without an extra round-trip.
+    j["timestamp"] = std::chrono::duration_cast<std::chrono::milliseconds>(
+                         std::chrono::system_clock::now().time_since_epoch())
+                         .count();
     pub_->put(zenoh::Bytes(j.dump()));
   }
 

--- a/src/core/control_runtime.hpp
+++ b/src/core/control_runtime.hpp
@@ -1,0 +1,142 @@
+#ifndef TELEOP_CONTROL_RUNTIME_HPP
+#define TELEOP_CONTROL_RUNTIME_HPP
+
+// Shared 60Hz control loop, parameterized on an input source and a telemetry
+// sink so the keyboard and Zenoh entries reuse one copy of the loop.
+
+#include "common/types.hpp"
+#include "core/mode_manager.hpp"
+#include "core/telemetry.hpp"
+#include "ros/manual_control_node.hpp"
+
+#include <chrono>
+#include <cmath>
+#include <memory>
+
+#include <rclcpp/rclcpp.hpp>
+
+namespace autoware::manual_control {
+
+struct RuntimeConfig {
+  double rate_hz = 60.0;
+  float shift_stop_tolerance = 0.05f; // m/s — speed below which a shift proceeds
+};
+
+// InputSource and TelemetrySink are duck-typed:
+//   InputSource:   InputState update();
+//   TelemetrySink: void publish(const Telemetry&);
+// On loss of fresh input the InputSource must return a safe InputState
+// (throttle 0, brake 1, steer 0) so the loop brakes without a special case.
+template <typename InputSource, typename TelemetrySink>
+void run_control_runtime(std::shared_ptr<ManualControlNode> node,
+                         InputSource &input, TelemetrySink &sink,
+                         const RuntimeConfig &cfg) {
+  ModeManager mode_manager;
+
+  if (node->should_start_external()) {
+    node->force_external_mode();
+  }
+
+  rclcpp::Rate rate(cfg.rate_hz);
+  auto last_time = std::chrono::steady_clock::now();
+
+  ShiftState shift_state = ShiftState::IDLE;
+  Gear pending_gear = Gear::PARK;
+
+  bool running = true;
+  while (rclcpp::ok() && running) {
+    auto now = std::chrono::steady_clock::now();
+    std::chrono::duration<float> dt_duration = now - last_time;
+    last_time = now;
+    float dt = dt_duration.count();
+    if (dt > 0.1f)
+      dt = 0.1f; // Cap max dt
+
+    // --- Input Phase ---
+    InputState input_state = input.update();
+
+    if (input_state.quit)
+      running = false;
+
+    // --- Logic Phase ---
+    if (input_state.toggle_auto) {
+      node->toggle_manual_control();
+    }
+
+    if (input_state.reset_pose) {
+      node->reset_initial_pose();
+    }
+
+    VehicleState vehicle_state = node->get_vehicle_state();
+
+    // Shift Request Handling (Stop-Wait-Shift)
+    if (input_state.shift_drive && vehicle_state.gear != Gear::DRIVE) {
+      pending_gear = Gear::DRIVE;
+      shift_state = ShiftState::STOPPING;
+    }
+    if (input_state.shift_reverse && vehicle_state.gear != Gear::REVERSE) {
+      pending_gear = Gear::REVERSE;
+      shift_state = ShiftState::STOPPING;
+    }
+    if (input_state.shift_park && vehicle_state.gear != Gear::PARK) {
+      pending_gear = Gear::PARK;
+      shift_state = ShiftState::STOPPING;
+    }
+
+    bool override_control = false;
+    ControlCommand override_cmd;
+
+    // State Machine
+    if (shift_state == ShiftState::STOPPING) {
+      override_control = true;
+      override_cmd.velocity = 0.0f;
+      override_cmd.acceleration = -10.0f; // Max Brake
+      override_cmd.steer_angle = vehicle_state.steer_angle;
+
+      if (std::abs(vehicle_state.velocity) < cfg.shift_stop_tolerance) {
+        node->set_target_gear(pending_gear);
+        shift_state = ShiftState::SHIFTING;
+      }
+    } else if (shift_state == ShiftState::SHIFTING) {
+      override_control = true;
+      override_cmd.velocity = 0.0f;
+      override_cmd.acceleration = -10.0f; // Hold Brake
+      override_cmd.steer_angle = vehicle_state.steer_angle;
+
+      if (vehicle_state.gear == pending_gear) {
+        mode_manager.reinit(vehicle_state);
+        shift_state = ShiftState::IDLE;
+        override_control = false;
+      }
+    }
+
+    // Update Mode Manager
+    mode_manager.update(dt, input_state, vehicle_state);
+    ControlCommand cmd = mode_manager.getCommand();
+
+    if (override_control) {
+      cmd = override_cmd;
+    }
+
+    // --- Output Phase ---
+    node->publish_command(cmd);
+
+    // --- Telemetry Phase ---
+    Telemetry t;
+    t.mode = mode_manager.getCurrentModeName();
+    t.mode_status = mode_manager.getStatusString();
+    t.vehicle = vehicle_state;
+    t.command = cmd;
+    t.shift_state = shift_state;
+    t.pending_gear = pending_gear;
+    t.info = node->get_info_message();
+    sink.publish(t);
+
+    rclcpp::spin_some(node);
+    rate.sleep();
+  }
+}
+
+} // namespace autoware::manual_control
+
+#endif // TELEOP_CONTROL_RUNTIME_HPP

--- a/src/core/control_runtime.hpp
+++ b/src/core/control_runtime.hpp
@@ -20,6 +20,7 @@ namespace autoware::manual_control {
 struct RuntimeConfig {
   double rate_hz = 60.0;
   float shift_stop_tolerance = 0.05f; // m/s — speed below which a shift proceeds
+  float shift_brake_accel = -10.0f;   // m/s^2 — override accel while shifting
 };
 
 // InputSource and TelemetrySink are duck-typed:
@@ -90,7 +91,7 @@ void run_control_runtime(std::shared_ptr<ManualControlNode> node,
     if (shift_state == ShiftState::STOPPING) {
       override_control = true;
       override_cmd.velocity = 0.0f;
-      override_cmd.acceleration = -10.0f; // Max Brake
+      override_cmd.acceleration = cfg.shift_brake_accel;
       override_cmd.steer_angle = vehicle_state.steer_angle;
 
       if (std::abs(vehicle_state.velocity) < cfg.shift_stop_tolerance) {
@@ -100,7 +101,7 @@ void run_control_runtime(std::shared_ptr<ManualControlNode> node,
     } else if (shift_state == ShiftState::SHIFTING) {
       override_control = true;
       override_cmd.velocity = 0.0f;
-      override_cmd.acceleration = -10.0f; // Hold Brake
+      override_cmd.acceleration = cfg.shift_brake_accel;
       override_cmd.steer_angle = vehicle_state.steer_angle;
 
       if (vehicle_state.gear == pending_gear) {

--- a/src/core/params_loader.hpp
+++ b/src/core/params_loader.hpp
@@ -1,0 +1,99 @@
+#ifndef TELEOP_PARAMS_LOADER_HPP
+#define TELEOP_PARAMS_LOADER_HPP
+
+// Loads runtime + per-mode parameters from a teleop_config.yaml-style ROS
+// parameter set and registers the default drive modes with those params.
+
+#include "core/control_runtime.hpp"
+#include "core/drive_mode_factory.hpp"
+#include "modes/cruise_mode.hpp"
+#include "modes/physics_mode.hpp"
+#include "modes/stop_mode.hpp"
+
+#include <memory>
+#include <rclcpp/rclcpp.hpp>
+#include <string>
+
+namespace autoware::manual_control {
+
+template <typename T>
+inline T load_param(rclcpp::Node &node, const std::string &name, const T &dflt) {
+  if (!node.has_parameter(name)) {
+    node.declare_parameter(name, dflt);
+  }
+  return node.get_parameter(name).get_value<T>();
+}
+
+// ROS params are doubles on the wire; the mode Params are floats. This helper
+// loads a numeric param (accepting either int or double) and returns a float.
+inline float load_float(rclcpp::Node &node, const std::string &name, float dflt) {
+  if (!node.has_parameter(name)) {
+    node.declare_parameter(name, static_cast<double>(dflt));
+  }
+  auto p = node.get_parameter(name);
+  return (p.get_type() == rclcpp::ParameterType::PARAMETER_INTEGER)
+             ? static_cast<float>(p.as_int())
+             : static_cast<float>(p.as_double());
+}
+
+inline RuntimeConfig load_runtime_config(rclcpp::Node &node) {
+  RuntimeConfig cfg;
+  cfg.rate_hz = load_param<double>(node, "control_rate_hz", cfg.rate_hz);
+  cfg.shift_stop_tolerance =
+      load_float(node, "shift_stop_tolerance", cfg.shift_stop_tolerance);
+  cfg.shift_brake_accel =
+      load_float(node, "shift_brake_accel", cfg.shift_brake_accel);
+  return cfg;
+}
+
+inline PhysicsDriveMode::Params load_physics_params(rclcpp::Node &node) {
+  PhysicsDriveMode::Params p;
+  p.max_speed = load_float(node, "physics.max_speed", p.max_speed);
+  p.max_steer = load_float(node, "physics.max_steer", p.max_steer);
+  p.steer_rate = load_float(node, "physics.steer_rate", p.steer_rate);
+  p.steer_decay = load_float(node, "physics.steer_decay", p.steer_decay);
+  p.steer_deadzone = load_float(node, "physics.steer_deadzone", p.steer_deadzone);
+  p.accel_max = load_float(node, "physics.accel_max", p.accel_max);
+  p.brake_max = load_float(node, "physics.brake_max", p.brake_max);
+  p.coast_decel = load_float(node, "physics.coast_decel", p.coast_decel);
+  return p;
+}
+
+inline CruiseDriveMode::Params load_cruise_params(rclcpp::Node &node) {
+  CruiseDriveMode::Params p;
+  p.max_speed = load_float(node, "cruise.max_speed", p.max_speed);
+  p.steer_rate = load_float(node, "cruise.steer_rate", p.steer_rate);
+  p.steer_limit = load_float(node, "cruise.steer_limit", p.steer_limit);
+  p.vel_inc_hold_kph_s =
+      load_float(node, "cruise.vel_inc_hold_kph_s", p.vel_inc_hold_kph_s);
+  p.vel_dec_hold_kph_s =
+      load_float(node, "cruise.vel_dec_hold_kph_s", p.vel_dec_hold_kph_s);
+  p.accel_p_gain = load_float(node, "cruise.accel_p_gain", p.accel_p_gain);
+  p.max_accel = load_float(node, "cruise.max_accel", p.max_accel);
+  p.min_accel = load_float(node, "cruise.min_accel", p.min_accel);
+  return p;
+}
+
+inline StopDriveMode::Params load_stop_params(rclcpp::Node &node) {
+  StopDriveMode::Params p;
+  p.brake_accel = load_float(node, "stop.brake_accel", p.brake_accel);
+  return p;
+}
+
+// Read each mode's params from the node and register a creator that captures
+// them. Both teleop entries call this so the wiring is single-sourced.
+inline void register_default_modes(DriveModeFactory &factory, rclcpp::Node &node) {
+  auto phys = load_physics_params(node);
+  auto cruise = load_cruise_params(node);
+  auto stop = load_stop_params(node);
+  factory.registerMode(ModeType::PHYSICS,
+                       [phys] { return std::make_unique<PhysicsDriveMode>(phys); });
+  factory.registerMode(ModeType::CRUISE,
+                       [cruise] { return std::make_unique<CruiseDriveMode>(cruise); });
+  factory.registerMode(ModeType::STOP,
+                       [stop] { return std::make_unique<StopDriveMode>(stop); });
+}
+
+} // namespace autoware::manual_control
+
+#endif // TELEOP_PARAMS_LOADER_HPP

--- a/src/core/params_loader.hpp
+++ b/src/core/params_loader.hpp
@@ -56,6 +56,8 @@ inline PhysicsDriveMode::Params load_physics_params(rclcpp::Node &node) {
   p.accel_max = load_float(node, "physics.accel_max", p.accel_max);
   p.brake_max = load_float(node, "physics.brake_max", p.brake_max);
   p.coast_decel = load_float(node, "physics.coast_decel", p.coast_decel);
+  p.max_vel_offset =
+      load_float(node, "physics.max_vel_offset", p.max_vel_offset);
   return p;
 }
 

--- a/src/core/telemetry.hpp
+++ b/src/core/telemetry.hpp
@@ -1,0 +1,25 @@
+#ifndef TELEOP_TELEMETRY_HPP
+#define TELEOP_TELEMETRY_HPP
+
+#include "common/types.hpp"
+
+#include <string>
+
+namespace autoware::manual_control {
+
+// Per-tick control snapshot, consumed by a TelemetrySink. Transport-agnostic:
+// medium-specific fields (keyboard key highlight, network client id) are not
+// here — each sink reads those from its own input.
+struct Telemetry {
+  std::string mode;
+  std::string mode_status;
+  VehicleState vehicle;   // measured
+  ControlCommand command; // commanded this tick
+  ShiftState shift_state = ShiftState::IDLE;
+  Gear pending_gear = Gear::NONE;
+  std::string info;
+};
+
+} // namespace autoware::manual_control
+
+#endif // TELEOP_TELEMETRY_HPP

--- a/src/input/input_system.hpp
+++ b/src/input/input_system.hpp
@@ -137,6 +137,15 @@ public:
     state.brake_hold = key_s_.is_holding_state();
     state.steer_dir = (a ? 1 : 0) + (d ? -1 : 0); // Left is +
 
+    // Drop held continuous inputs on auto/local toggle so the new mode
+    // starts from a fresh release.
+    if (state.toggle_auto) {
+      key_w_.reset();
+      key_s_.reset();
+      key_a_.reset();
+      key_d_.reset();
+    }
+
     return state;
   }
 

--- a/src/keyboard_control.cpp
+++ b/src/keyboard_control.cpp
@@ -1,9 +1,11 @@
-#include <chrono>
+// Standalone keyboard teleop entry point.
+
 #include <memory>
+
 #include <rclcpp/rclcpp.hpp>
-#include <thread>
 
 #include "common/types.hpp"
+#include "core/control_runtime.hpp"
 #include "core/drive_mode_factory.hpp"
 #include "core/mode_manager.hpp"
 #include "input/input_system.hpp"
@@ -13,134 +15,28 @@
 #include "ros/manual_control_node.hpp"
 #include "ui/console_ui.hpp"
 
+using namespace autoware::manual_control;
+
 int main(int argc, char *argv[]) {
   rclcpp::init(argc, argv);
 
-  // 1. Initialize Components
   // Register Modes
-  auto &factory = autoware::manual_control::DriveModeFactory::instance();
-  factory.registerMode(ModeType::PHYSICS, []() {
-    return std::make_unique<autoware::manual_control::PhysicsDriveMode>();
-  });
-  factory.registerMode(ModeType::CRUISE, []() {
-    return std::make_unique<autoware::manual_control::CruiseDriveMode>();
-  });
-  factory.registerMode(ModeType::STOP, []() {
-    return std::make_unique<autoware::manual_control::StopDriveMode>();
-  });
+  auto &factory = DriveModeFactory::instance();
+  factory.registerMode(ModeType::PHYSICS,
+                       []() { return std::make_unique<PhysicsDriveMode>(); });
+  factory.registerMode(ModeType::CRUISE,
+                       []() { return std::make_unique<CruiseDriveMode>(); });
+  factory.registerMode(ModeType::STOP,
+                       []() { return std::make_unique<StopDriveMode>(); });
 
-  auto node = std::make_shared<autoware::manual_control::ManualControlNode>();
-  autoware::manual_control::InputSystem input_system;
-  autoware::manual_control::ModeManager mode_manager;
-  autoware::manual_control::ConsoleUI ui;
+  auto node = std::make_shared<ManualControlNode>();
+  InputSystem input_system;
+  ConsoleUI ui(input_system);
 
-  // 2. Setup
-  ui.init(); // 3. Main Loop
-  if (node->should_start_external()) {
-    node->force_external_mode();
-  }
+  ui.init();
 
-  rclcpp::Rate rate(60);
-  auto last_time = std::chrono::steady_clock::now();
-
-  // Shift Safety State
-  ShiftState shift_state = ShiftState::IDLE;
-  Gear pending_gear = Gear::PARK;
-
-  bool running = true;
-  while (rclcpp::ok() && running) {
-    auto now = std::chrono::steady_clock::now();
-    std::chrono::duration<float> dt_duration = now - last_time;
-    last_time = now;
-    float dt = dt_duration.count();
-    if (dt > 0.1f)
-      dt = 0.1f; // Cap max dt
-
-    // --- Input Phase ---
-    InputState input = input_system.update();
-
-    if (input.quit)
-      running = false;
-
-    // --- Logic Phase ---
-
-    if (input.toggle_auto) {
-      node->toggle_manual_control();
-      // Reset input state on toggle
-      input_system.reset();
-    }
-
-    if (input.reset_pose) {
-      node->reset_initial_pose();
-    }
-
-    // Get Vehicle State early for logic checks
-    VehicleState vehicle_state = node->get_vehicle_state();
-
-    // Shift Request Handling (Stop-Wait-Shift)
-    if (input.shift_drive && vehicle_state.gear != Gear::DRIVE) {
-      pending_gear = Gear::DRIVE;
-      shift_state = ShiftState::STOPPING;
-    }
-    if (input.shift_reverse && vehicle_state.gear != Gear::REVERSE) {
-      pending_gear = Gear::REVERSE;
-      shift_state = ShiftState::STOPPING;
-    }
-    if (input.shift_park && vehicle_state.gear != Gear::PARK) {
-      pending_gear = Gear::PARK;
-      shift_state = ShiftState::STOPPING;
-    }
-
-    bool override_control = false;
-    ControlCommand override_cmd;
-
-    // State Machine
-    if (shift_state == ShiftState::STOPPING) {
-      override_control = true;
-      override_cmd.velocity = 0.0f;
-      override_cmd.acceleration = -10.0f; // Max Brake
-      override_cmd.steer_angle = vehicle_state.steer_angle;
-
-      // Wait for Stop (0.05 m/s tolerance)
-      if (std::abs(vehicle_state.velocity) < 0.05f) {
-        node->set_target_gear(pending_gear);
-        shift_state = ShiftState::SHIFTING;
-      }
-    } else if (shift_state == ShiftState::SHIFTING) {
-      override_control = true;
-      override_cmd.velocity = 0.0f;
-      override_cmd.acceleration = -10.0f; // Hold Brake
-      override_cmd.steer_angle = vehicle_state.steer_angle;
-
-      // Wait for Gear Confirmation
-      if (vehicle_state.gear == pending_gear) {
-        mode_manager.reinit(vehicle_state);
-        shift_state = ShiftState::IDLE;
-        override_control = false;
-      }
-    }
-
-    // Get Vehicle State (Already retrieved above)
-
-    // Update Mode Manager
-    mode_manager.update(dt, input, vehicle_state);
-    ControlCommand cmd = mode_manager.getCommand();
-
-    if (override_control) {
-      cmd = override_cmd;
-    }
-
-    // --- Output Phase ---
-    node->publish_command(cmd);
-
-    // --- UI Phase ---
-    ui.refresh(input_system, mode_manager, vehicle_state, cmd, shift_state,
-               pending_gear, node->get_info_message());
-
-    // ROS Spin
-    rclcpp::spin_some(node);
-    rate.sleep();
-  }
+  RuntimeConfig cfg;
+  run_control_runtime(node, input_system, ui, cfg);
 
   rclcpp::shutdown();
   return 0;

--- a/src/keyboard_control.cpp
+++ b/src/keyboard_control.cpp
@@ -4,14 +4,10 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include "common/types.hpp"
 #include "core/control_runtime.hpp"
 #include "core/drive_mode_factory.hpp"
-#include "core/mode_manager.hpp"
+#include "core/params_loader.hpp"
 #include "input/input_system.hpp"
-#include "modes/cruise_mode.hpp"
-#include "modes/physics_mode.hpp"
-#include "modes/stop_mode.hpp"
 #include "ros/manual_control_node.hpp"
 #include "ui/console_ui.hpp"
 
@@ -20,22 +16,14 @@ using namespace autoware::manual_control;
 int main(int argc, char *argv[]) {
   rclcpp::init(argc, argv);
 
-  // Register Modes
-  auto &factory = DriveModeFactory::instance();
-  factory.registerMode(ModeType::PHYSICS,
-                       []() { return std::make_unique<PhysicsDriveMode>(); });
-  factory.registerMode(ModeType::CRUISE,
-                       []() { return std::make_unique<CruiseDriveMode>(); });
-  factory.registerMode(ModeType::STOP,
-                       []() { return std::make_unique<StopDriveMode>(); });
-
   auto node = std::make_shared<ManualControlNode>();
+  register_default_modes(DriveModeFactory::instance(), *node);
+
   InputSystem input_system;
   ConsoleUI ui(input_system);
-
   ui.init();
 
-  RuntimeConfig cfg;
+  RuntimeConfig cfg = load_runtime_config(*node);
   run_control_runtime(node, input_system, ui, cfg);
 
   rclcpp::shutdown();

--- a/src/modes/cruise_mode.hpp
+++ b/src/modes/cruise_mode.hpp
@@ -4,99 +4,92 @@
 #include "core/drive_mode.hpp"
 #include <algorithm>
 #include <cmath>
-#include <cstdio>
 #include <string>
 
 namespace autoware::manual_control {
 
-// ==========================================
-// Cruise Mode: Setpoint based with Steering Lock
-// ==========================================
+// Setpoint-based mode: throttle/brake taps adjust target speed in 1 km/h
+// steps; holding ramps continuously. A P-controller produces the
+// acceleration command from the speed error.
 class CruiseDriveMode : public DriveMode {
 public:
-  void onEnter(const VehicleState &current_state) override {
-    target_speed_ = std::abs(current_state.velocity);
+  struct Params {
+    float max_speed = 27.78f;          // m/s (100 km/h)
+    float steer_rate = 0.3f;           // rad/s
+    float steer_limit = 0.6f;          // rad
+    float vel_inc_hold_kph_s = 5.0f;   // km/h per second when holding throttle
+    float vel_dec_hold_kph_s = 10.0f;  // km/h per second when holding brake
+    float accel_p_gain = 3.0f;
+    float max_accel = 5.0f;
+    float min_accel = -10.0f;
+  };
 
-    // Safety clamp on entry
-    if (target_speed_ > MAX_SPEED)
-      target_speed_ = 0.0f;
+  explicit CruiseDriveMode(const Params &params) : params_(params) {}
 
-    // Reset if entering in Reverse (Safety)
-    if (current_state.gear == Gear::REVERSE) {
+  void onEnter(const VehicleState &state) override {
+    target_speed_ = std::abs(state.velocity);
+    if (target_speed_ > params_.max_speed) {
       target_speed_ = 0.0f;
     }
-
-    current_steer_ = current_state.steer_angle;
-
-    // Reset toggle states
+    if (state.gear == Gear::REVERSE) {
+      target_speed_ = 0.0f;
+    }
+    current_steer_ = state.steer_angle;
     last_throttle_press_ = false;
     last_brake_press_ = false;
-
-    // Initialize Gear Tracker
-    last_gear_ = current_state.gear;
+    last_gear_ = state.gear;
   }
 
   ControlCommand update(float dt, const InputState &input,
                         const VehicleState &vehicle_state) override {
-
-    // Safety: Reset Setpoint on ANY Gear Change
     if (vehicle_state.gear != last_gear_) {
       target_speed_ = 0.0f;
       last_gear_ = vehicle_state.gear;
     }
 
-    // 1. Steering (Lock Logic - No Auto-Centering)
+    // Steering (no auto-centering: held angle persists).
     if (input.steer_dir != 0) {
-      current_steer_ += input.steer_dir * STEER_RATE * dt;
+      current_steer_ += input.steer_dir * params_.steer_rate * dt;
     }
-    current_steer_ = std::clamp(current_steer_, -STEER_LIMIT, STEER_LIMIT);
+    current_steer_ =
+        std::clamp(current_steer_, -params_.steer_limit, params_.steer_limit);
 
-    // 2. Velocity (Setpoint) with Tap/Hold Logic
     if (vehicle_state.gear == Gear::PARK) {
       target_speed_ = 0.0f;
     } else {
-      // Throttle Logic
-      bool throttle_active = (input.throttle > 0);
+      const float inc_per_s = params_.vel_inc_hold_kph_s / 3.6f;
+      const float dec_per_s = params_.vel_dec_hold_kph_s / 3.6f;
+
+      bool throttle_active = (input.throttle > 0.0f);
       if (throttle_active) {
         if (input.throttle_hold) {
-          // Holding: Continuous increase
-          target_speed_ += VEL_INC_HOLD * dt;
-        } else {
-          // Tapping (Rising Edge): Snap to next integer km/h
-          if (!last_throttle_press_) {
-            float current_kph = target_speed_ * 3.6f;
-            float next_kph = std::floor(current_kph) + 1.0f;
-            target_speed_ = next_kph / 3.6f;
-          }
+          target_speed_ += inc_per_s * dt;
+        } else if (!last_throttle_press_) {
+          // Rising edge: snap to next integer km/h.
+          float current_kph = target_speed_ * 3.6f;
+          target_speed_ = (std::floor(current_kph) + 1.0f) / 3.6f;
         }
       }
       last_throttle_press_ = throttle_active;
 
-      // Brake Logic (Decrement)
-      bool brake_active = (input.brake > 0);
+      bool brake_active = (input.brake > 0.0f);
       if (brake_active) {
         if (input.brake_hold) {
-          // Holding: Continuous decrease
-          target_speed_ -= VEL_DEC_HOLD * dt;
-        } else {
-          // Tapping (Rising Edge): Snap to prev integer km/h
-          if (!last_brake_press_) {
-            float current_kph = target_speed_ * 3.6f;
-            float next_kph = std::ceil(current_kph) - 1.0f;
-            target_speed_ = next_kph / 3.6f;
-          }
+          target_speed_ -= dec_per_s * dt;
+        } else if (!last_brake_press_) {
+          float current_kph = target_speed_ * 3.6f;
+          target_speed_ = (std::ceil(current_kph) - 1.0f) / 3.6f;
         }
       }
       last_brake_press_ = brake_active;
     }
 
-    target_speed_ = std::clamp(target_speed_, 0.0f, MAX_SPEED);
+    target_speed_ = std::clamp(target_speed_, 0.0f, params_.max_speed);
 
-    // P-Control for Accel
+    // P-control for acceleration command.
     float real_speed = std::abs(vehicle_state.velocity);
-    float error = target_speed_ - real_speed;
-    float accel_cmd = error * ACCEL_P_GAIN;
-    accel_cmd = std::clamp(accel_cmd, MIN_ACCEL, MAX_ACCEL);
+    float accel_cmd = (target_speed_ - real_speed) * params_.accel_p_gain;
+    accel_cmd = std::clamp(accel_cmd, params_.min_accel, params_.max_accel);
 
     ControlCommand cmd;
     cmd.velocity = target_speed_;
@@ -106,26 +99,13 @@ public:
   }
 
   std::string getName() const override { return "CRUISE"; }
-  std::string getStatusString() const override {
-    return ""; // Standard UI shows Set speed
-  }
+  std::string getStatusString() const override { return ""; }
 
 private:
-  // Constants
-  static constexpr float MAX_SPEED = 27.78f;          // 100 km/h
-  static constexpr float STEER_RATE = 0.3f;           // rad/s
-  static constexpr float STEER_LIMIT = 0.6f;          // rad (~34 deg)
-  static constexpr float VEL_INC_HOLD = 5.0f / 3.6f;  // +5 km/h per sec
-  static constexpr float VEL_DEC_HOLD = 10.0f / 3.6f; // -10 km/h per sec
-  static constexpr float ACCEL_P_GAIN = 3.0f;
-  static constexpr float MAX_ACCEL = 5.0f;
-  static constexpr float MIN_ACCEL = -10.0f;
-
+  Params params_;
   float target_speed_ = 0.0f;
   float current_steer_ = 0.0f;
   Gear last_gear_ = Gear::PARK;
-
-  // Edge detection for Tap
   bool last_throttle_press_ = false;
   bool last_brake_press_ = false;
 };

--- a/src/modes/physics_mode.hpp
+++ b/src/modes/physics_mode.hpp
@@ -11,18 +11,21 @@ namespace autoware::manual_control {
 
 // Direct mapping: input -> desired acceleration -> integrate -> velocity
 // setpoint. The vehicle controller downstream owns velocity tracking; we do
-// not stack a second loop on top of it.
+// not stack a second loop on top of it. One anti-windup constraint guards
+// the setpoint against runaway when the downstream is feed-forward (no
+// tracker) — see the std::min() in update() below.
 class PhysicsDriveMode : public DriveMode {
 public:
   struct Params {
-    float max_speed = 27.78f;      // m/s (100 km/h)
-    float max_steer = 0.6f;        // rad
-    float steer_rate = 0.8f;       // rad/s while a steer key is held
-    float steer_decay = 1.0f;      // rad/s auto-center on release
-    float steer_deadzone = 0.01f;  // rad
-    float accel_max = 3.5f;        // m/s^2 at full throttle
-    float brake_max = 5.0f;        // m/s^2 at full brake
-    float coast_decel = 2.0f;      // m/s^2 with no input (engine braking)
+    float max_speed = 27.78f;       // m/s (100 km/h)
+    float max_steer = 0.6f;         // rad
+    float steer_rate = 0.8f;        // rad/s while a steer key is held
+    float steer_decay = 1.0f;       // rad/s auto-center on release
+    float steer_deadzone = 0.01f;   // rad
+    float accel_max = 3.5f;         // m/s^2 at full throttle
+    float brake_max = 5.0f;         // m/s^2 at full brake
+    float coast_decel = 2.0f;       // m/s^2 with no input (engine braking)
+    float max_vel_offset = 3.0f;    // m/s — setpoint may lead real by this much
   };
 
   explicit PhysicsDriveMode(const Params &params) : params_(params) {}
@@ -69,9 +72,16 @@ public:
       desired_accel = -params_.coast_decel;
     }
 
-    // Integrate to velocity setpoint, clamped to [0, max_speed].
-    desired_vel_ =
-        std::clamp(desired_vel_ + desired_accel * dt, 0.0f, params_.max_speed);
+    // Integrate to velocity setpoint, clamped to [0, max_speed]. The
+    // downstream raw_vehicle_cmd_converter is a feed-forward accel→throttle
+    // map with no velocity tracker, so without anti-windup desired_vel_
+    // would race past max_speed while real is still climbing; the cap below
+    // would then zero realized_accel and the converter's Y=0 row would turn
+    // into a brake — the historical 0→18→0 cycle.
+    desired_vel_ += desired_accel * dt;
+    desired_vel_ = std::min(desired_vel_,
+                            std::abs(vehicle_state.velocity) + params_.max_vel_offset);
+    desired_vel_ = std::clamp(desired_vel_, 0.0f, params_.max_speed);
 
     // Pass the operator's acceleration intent through, except cap positive
     // intent at the upper bound (otherwise the downstream controller pushes

--- a/src/modes/physics_mode.hpp
+++ b/src/modes/physics_mode.hpp
@@ -9,103 +9,85 @@
 
 namespace autoware::manual_control {
 
+// Direct mapping: input -> desired acceleration -> integrate -> velocity
+// setpoint. The vehicle controller downstream owns velocity tracking; we do
+// not stack a second loop on top of it.
 class PhysicsDriveMode : public DriveMode {
 public:
-  void onEnter(const VehicleState &current_state) override {
-    current_vel_ = std::abs(current_state.velocity);
-    current_steer_ = current_state.steer_angle;
-    current_accel_ = 0.0f;
-    current_accel_rate_ = 0.0f;
-    last_gear_ = current_state.gear;
+  struct Params {
+    float max_speed = 27.78f;      // m/s (100 km/h)
+    float max_steer = 0.6f;        // rad
+    float steer_rate = 0.8f;       // rad/s while a steer key is held
+    float steer_decay = 1.0f;      // rad/s auto-center on release
+    float steer_deadzone = 0.01f;  // rad
+    float accel_max = 3.5f;        // m/s^2 at full throttle
+    float brake_max = 5.0f;        // m/s^2 at full brake
+    float coast_decel = 2.0f;      // m/s^2 with no input (engine braking)
+  };
+
+  explicit PhysicsDriveMode(const Params &params) : params_(params) {}
+
+  void onEnter(const VehicleState &state) override {
+    desired_vel_ = std::abs(state.velocity);
+    current_steer_ = state.steer_angle;
+    last_gear_ = state.gear;
+    status_accel_ = 0.0f;
   }
 
   ControlCommand update(float dt, const InputState &input,
                         const VehicleState &vehicle_state) override {
-
-    // Debounced gear-change reset; raw transitions flicker.
+    // Gear change wipes the velocity setpoint to avoid carrying speed across
+    // a direction reverse.
     if (vehicle_state.gear != last_gear_) {
-      gear_debounce_count_++;
-      if (gear_debounce_count_ >= GEAR_DEBOUNCE_TICKS) {
-        current_vel_ = 0.0f;
-        current_accel_ = 0.0f;
-        current_accel_rate_ = 0.0f;
-        last_gear_ = vehicle_state.gear;
-        gear_debounce_count_ = 0;
-      }
-    } else {
-      gear_debounce_count_ = 0;
+      desired_vel_ = 0.0f;
+      last_gear_ = vehicle_state.gear;
     }
 
+    // Steering: integrate rate to angle; auto-center toward zero on release.
     if (input.steer_dir != 0) {
-      current_steer_ += input.steer_dir * params_.steer_attack * dt;
-    } else {
-      if (std::abs(current_steer_) > params_.steer_deadzone) {
-        float decay = params_.steer_decay * dt;
-        if (current_steer_ > 0) {
-          current_steer_ = std::max(0.0f, current_steer_ - decay);
-        } else {
-          current_steer_ = std::min(0.0f, current_steer_ + decay);
-        }
+      current_steer_ += input.steer_dir * params_.steer_rate * dt;
+    } else if (std::abs(current_steer_) > params_.steer_deadzone) {
+      float step = params_.steer_decay * dt;
+      if (current_steer_ > 0) {
+        current_steer_ = std::max(0.0f, current_steer_ - step);
       } else {
-        current_steer_ = 0;
+        current_steer_ = std::min(0.0f, current_steer_ + step);
       }
+    } else {
+      current_steer_ = 0.0f;
     }
     current_steer_ =
         std::clamp(current_steer_, -params_.max_steer, params_.max_steer);
 
-    float real_speed_mag = std::abs(vehicle_state.velocity);
-
-    // Anchor target to actual speed during coast so target leads downward;
-    // min() prevents target from re-inflating after inertia overshoot.
-    if (input.throttle == 0.0f && input.brake == 0.0f) {
-      float anchor = std::min(current_vel_, real_speed_mag);
-      float decayed = anchor - params_.coast_decel * dt;
-      current_vel_ = std::max(0.0f, decayed);
+    // Input -> acceleration intent (linear, immediate).
+    float desired_accel;
+    if (input.throttle > 0.0f) {
+      desired_accel = input.throttle * params_.accel_max;
+    } else if (input.brake > 0.0f) {
+      desired_accel = -input.brake * params_.brake_max;
+    } else {
+      desired_accel = -params_.coast_decel;
     }
 
-    if (input.throttle > 0) {
-      current_accel_rate_ = input.throttle * 4.0f;
-      current_vel_ += current_accel_rate_ * dt;
-    } else if (input.brake > 0) {
-      current_vel_ -= input.brake * params_.brake_rate * dt;
-      if (current_vel_ < 0) current_vel_ = 0;
-    }
+    // Integrate to velocity setpoint, clamped to [0, max_speed].
+    desired_vel_ =
+        std::clamp(desired_vel_ + desired_accel * dt, 0.0f, params_.max_speed);
 
-    // Anti-windup against delayed vehicle_state (real_speed=0 stale → runaway).
-    current_vel_ = std::min(current_vel_, real_speed_mag + params_.max_vel_offset);
-    current_vel_ = std::clamp(current_vel_, 0.0f, params_.max_speed);
+    // Pass the operator's acceleration intent through, except cap positive
+    // intent at the upper bound (otherwise the downstream controller pushes
+    // past max_speed). At the lower bound we keep the negative intent so the
+    // controller keeps braking until the real speed reaches 0 — the gear
+    // direction prevents the vehicle from going past zero on its own.
+    float realized_accel = desired_accel;
+    if (desired_vel_ >= params_.max_speed && realized_accel > 0.0f) {
+      realized_accel = 0.0f;
+    }
 
     ControlCommand cmd;
-    // Autoware 1.5+: velocity must be positive magnitude; sign comes from GearCommand.
-    cmd.velocity = current_vel_;
-
-    float accel_cmd_mag = 0.0f;
-    const float vel_error = current_vel_ - real_speed_mag;
-    if (input.throttle > 0) {
-      float base_accel = input.throttle * params_.accel_max;
-      float ratio = std::clamp(vel_error / params_.accel_taper_range, 0.0f, 1.0f);
-      accel_cmd_mag = base_accel * ratio;
-      // Minimum accel so the vehicle starts moving from standstill.
-      if (real_speed_mag < 0.5f && input.throttle > 0.5f)
-        accel_cmd_mag = std::max(accel_cmd_mag, params_.accel_min_start);
-    } else if (input.brake > 0) {
-      accel_cmd_mag = -input.brake * params_.brake_accel;
-    } else {
-      accel_cmd_mag = (real_speed_mag > 0.1f) ? -params_.coast_decel * 1.5f : 0.0f;
-    }
-
-    // Overshoot brake: real exceeds target → corrective decel regardless of input.
-    const float overshoot = real_speed_mag - current_vel_;
-    if (overshoot > 0.3f) {  // deadzone to avoid oscillation
-      float correction = -overshoot * params_.overshoot_p_gain;
-      accel_cmd_mag = std::min(accel_cmd_mag, correction);
-    }
-
-    cmd.acceleration = accel_cmd_mag;
+    cmd.velocity = desired_vel_;
+    cmd.acceleration = realized_accel;
     cmd.steer_angle = current_steer_;
-
-    current_accel_ = accel_cmd_mag;
-
+    status_accel_ = realized_accel;
     return cmd;
   }
 
@@ -113,35 +95,16 @@ public:
 
   std::string getStatusString() const override {
     char buf[64];
-    snprintf(buf, sizeof(buf), "Acc: %.2f m/s2", current_accel_);
+    std::snprintf(buf, sizeof(buf), "Acc: %.2f m/s2", status_accel_);
     return std::string(buf);
   }
 
 private:
-  // Magnitude only; sign comes from gear.
-  float current_vel_ = 0.0f;
+  Params params_;
+  float desired_vel_ = 0.0f;
   float current_steer_ = 0.0f;
-  float current_accel_ = 0.0f;
-  float current_accel_rate_ = 0.0f;
+  float status_accel_ = 0.0f;
   Gear last_gear_ = Gear::PARK;
-  int gear_debounce_count_ = 0;
-  static constexpr int GEAR_DEBOUNCE_TICKS = 6;  // ~100ms at 60Hz
-
-  struct Params {
-    float max_speed = 27.78f;
-    float max_steer = 0.6f;
-    float steer_attack = 0.8f;
-    float steer_decay = 1.0f;
-    float steer_deadzone = 0.01f;
-    float brake_rate = 10.0f;
-    float brake_accel = 5.0f;     // m/s^2 brake command magnitude
-    float coast_decel = 2.0f;     // m/s^2 engine braking when coasting
-    float max_vel_offset = 3.0f;  // m/s — anti-windup clamp
-    float accel_max = 3.5f;       // m/s^2 max acceleration command
-    float accel_taper_range = 3.0f; // m/s — P-control range: full accel at this error, 0 at error=0
-    float accel_min_start = 1.0f; // m/s^2 minimum accel from standstill
-    float overshoot_p_gain = 3.0f; // P-gain for active overshoot correction
-  } params_;
 };
 
 } // namespace autoware::manual_control

--- a/src/modes/physics_mode.hpp
+++ b/src/modes/physics_mode.hpp
@@ -9,14 +9,10 @@
 
 namespace autoware::manual_control {
 
-// ==========================================
-// Physics Mode: Inertia-based control
-// ==========================================
 class PhysicsDriveMode : public DriveMode {
 public:
   void onEnter(const VehicleState &current_state) override {
-    // Always start with absolute speed concept
-    current_vel_ = std::abs(current_state.velocity); // seamless handover
+    current_vel_ = std::abs(current_state.velocity);
     current_steer_ = current_state.steer_angle;
     current_accel_ = 0.0f;
     current_accel_rate_ = 0.0f;
@@ -26,27 +22,30 @@ public:
   ControlCommand update(float dt, const InputState &input,
                         const VehicleState &vehicle_state) override {
 
-    // Safety: Reset State on Gear Change
+    // Debounced gear-change reset; raw transitions flicker.
     if (vehicle_state.gear != last_gear_) {
-      current_vel_ = 0.0f;
-      current_accel_ = 0.0f;
-      current_accel_rate_ = 0.0f;
-      last_gear_ = vehicle_state.gear;
+      gear_debounce_count_++;
+      if (gear_debounce_count_ >= GEAR_DEBOUNCE_TICKS) {
+        current_vel_ = 0.0f;
+        current_accel_ = 0.0f;
+        current_accel_rate_ = 0.0f;
+        last_gear_ = vehicle_state.gear;
+        gear_debounce_count_ = 0;
+      }
+    } else {
+      gear_debounce_count_ = 0;
     }
 
-    // 1. Steering Physics (Attack/Decay)
     if (input.steer_dir != 0) {
       current_steer_ += input.steer_dir * params_.steer_attack * dt;
     } else {
-      // Auto-center
-      if (current_steer_ > params_.steer_deadzone) {
-        current_steer_ -= params_.steer_decay * dt;
-        if (current_steer_ < 0)
-          current_steer_ = 0;
-      } else if (current_steer_ < -params_.steer_deadzone) {
-        current_steer_ += params_.steer_decay * dt;
-        if (current_steer_ > 0)
-          current_steer_ = 0;
+      if (std::abs(current_steer_) > params_.steer_deadzone) {
+        float decay = params_.steer_decay * dt;
+        if (current_steer_ > 0) {
+          current_steer_ = std::max(0.0f, current_steer_ - decay);
+        } else {
+          current_steer_ = std::min(0.0f, current_steer_ + decay);
+        }
       } else {
         current_steer_ = 0;
       }
@@ -54,60 +53,58 @@ public:
     current_steer_ =
         std::clamp(current_steer_, -params_.max_steer, params_.max_steer);
 
-    // 2. Velocity Physics (Magnitude Based)
     float real_speed_mag = std::abs(vehicle_state.velocity);
 
-    // Acceleration Ramp
+    // Anchor target to actual speed during coast so target leads downward;
+    // min() prevents target from re-inflating after inertia overshoot.
+    if (input.throttle == 0.0f && input.brake == 0.0f) {
+      float anchor = std::min(current_vel_, real_speed_mag);
+      float decayed = anchor - params_.coast_decel * dt;
+      current_vel_ = std::max(0.0f, decayed);
+    }
+
     if (input.throttle > 0) {
-      current_accel_rate_ = std::min(current_accel_rate_ + 1.0f, 9.0f);
-    } else {
-      current_accel_rate_ = 0.0f;
-      // Anti-ghosting: Check if Target (Magnitude) >> Real (Magnitude)
-      // If we are commanding 5.0, but real is 0.0, and throttle released ->
-      // snap
-      if (current_vel_ > real_speed_mag + 2.0f) {
-        current_vel_ = real_speed_mag + 0.5f;
-      }
+      current_accel_rate_ = input.throttle * 4.0f;
+      current_vel_ += current_accel_rate_ * dt;
+    } else if (input.brake > 0) {
+      current_vel_ -= input.brake * params_.brake_rate * dt;
+      if (current_vel_ < 0) current_vel_ = 0;
     }
 
-    // Apply Acceleration (Increase Magnitude)
-    current_vel_ += (input.throttle > 0 ? current_accel_rate_ : 0.0f) * dt;
-
-    // Apply Braking (Decrease Magnitude)
-    if (input.brake > 0) {
-      // Linear decrease
-      if (current_vel_ > 0) {
-        current_vel_ -= params_.brake_rate * dt;
-        if (current_vel_ < 0)
-          current_vel_ = 0;
-      }
-    }
-
-    // Apply Friction (Decrease Magnitude)
-    float friction = params_.friction_rate;
-    if (vehicle_state.gear == Gear::PARK)
-      friction = 10.0f;
-
-    if (current_vel_ > 0) {
-      current_vel_ -= friction * dt;
-      if (current_vel_ < 0)
-        current_vel_ = 0;
-    }
-
+    // Anti-windup against delayed vehicle_state (real_speed=0 stale → runaway).
+    current_vel_ = std::min(current_vel_, real_speed_mag + params_.max_vel_offset);
     current_vel_ = std::clamp(current_vel_, 0.0f, params_.max_speed);
 
-    // Calculate Acceleration Command (Derivative)
-    // Calculated based on speed magnitude to prevent sign flip instability
-    // during direction changes
-    float accel_cmd = 0.0f;
-    if (dt > 1e-4) {
-      accel_cmd = (current_vel_ - real_speed_mag) / dt;
+    ControlCommand cmd;
+    // Autoware 1.5+: velocity must be positive magnitude; sign comes from GearCommand.
+    cmd.velocity = current_vel_;
+
+    float accel_cmd_mag = 0.0f;
+    const float vel_error = current_vel_ - real_speed_mag;
+    if (input.throttle > 0) {
+      float base_accel = input.throttle * params_.accel_max;
+      float ratio = std::clamp(vel_error / params_.accel_taper_range, 0.0f, 1.0f);
+      accel_cmd_mag = base_accel * ratio;
+      // Minimum accel so the vehicle starts moving from standstill.
+      if (real_speed_mag < 0.5f && input.throttle > 0.5f)
+        accel_cmd_mag = std::max(accel_cmd_mag, params_.accel_min_start);
+    } else if (input.brake > 0) {
+      accel_cmd_mag = -input.brake * params_.brake_accel;
+    } else {
+      accel_cmd_mag = (real_speed_mag > 0.1f) ? -params_.coast_decel * 1.5f : 0.0f;
     }
 
-    ControlCommand cmd;
-    cmd.velocity = current_vel_;
-    cmd.acceleration = accel_cmd;
+    // Overshoot brake: real exceeds target → corrective decel regardless of input.
+    const float overshoot = real_speed_mag - current_vel_;
+    if (overshoot > 0.3f) {  // deadzone to avoid oscillation
+      float correction = -overshoot * params_.overshoot_p_gain;
+      accel_cmd_mag = std::min(accel_cmd_mag, correction);
+    }
+
+    cmd.acceleration = accel_cmd_mag;
     cmd.steer_angle = current_steer_;
+
+    current_accel_ = accel_cmd_mag;
 
     return cmd;
   }
@@ -121,12 +118,14 @@ public:
   }
 
 private:
-  // We track Magnitude (Speed) here, assumed positive
+  // Magnitude only; sign comes from gear.
   float current_vel_ = 0.0f;
   float current_steer_ = 0.0f;
   float current_accel_ = 0.0f;
   float current_accel_rate_ = 0.0f;
   Gear last_gear_ = Gear::PARK;
+  int gear_debounce_count_ = 0;
+  static constexpr int GEAR_DEBOUNCE_TICKS = 6;  // ~100ms at 60Hz
 
   struct Params {
     float max_speed = 27.78f;
@@ -135,7 +134,13 @@ private:
     float steer_decay = 1.0f;
     float steer_deadzone = 0.01f;
     float brake_rate = 10.0f;
-    float friction_rate = 3.0f;
+    float brake_accel = 5.0f;     // m/s^2 brake command magnitude
+    float coast_decel = 2.0f;     // m/s^2 engine braking when coasting
+    float max_vel_offset = 3.0f;  // m/s — anti-windup clamp
+    float accel_max = 3.5f;       // m/s^2 max acceleration command
+    float accel_taper_range = 3.0f; // m/s — P-control range: full accel at this error, 0 at error=0
+    float accel_min_start = 1.0f; // m/s^2 minimum accel from standstill
+    float overshoot_p_gain = 3.0f; // P-gain for active overshoot correction
   } params_;
 };
 

--- a/src/modes/stop_mode.hpp
+++ b/src/modes/stop_mode.hpp
@@ -6,20 +6,26 @@
 
 namespace autoware::manual_control {
 
-// ==========================================
-// Stop Mode
-// ==========================================
 class StopDriveMode : public DriveMode {
 public:
+  struct Params {
+    float brake_accel = -10.0f; // m/s^2
+  };
+
+  explicit StopDriveMode(const Params &params) : params_(params) {}
+
   ControlCommand update(float /*dt*/, const InputState & /*input*/,
                         const VehicleState & /*vehicle_state*/) override {
     ControlCommand cmd;
     cmd.velocity = 0.0f;
-    cmd.acceleration = -10.0f; // Strong brake
-    cmd.steer_angle = 0.0f;    // Center for safety
+    cmd.acceleration = params_.brake_accel;
+    cmd.steer_angle = 0.0f;
     return cmd;
   }
   std::string getName() const override { return "STOP"; }
+
+private:
+  Params params_;
 };
 
 } // namespace autoware::manual_control

--- a/src/remote_control.cpp
+++ b/src/remote_control.cpp
@@ -11,12 +11,9 @@
 
 #include "bridge/zenoh/zenoh_input.hpp"
 #include "bridge/zenoh/zenoh_telemetry.hpp"
-#include "common/types.hpp"
 #include "core/control_runtime.hpp"
 #include "core/drive_mode_factory.hpp"
-#include "modes/cruise_mode.hpp"
-#include "modes/physics_mode.hpp"
-#include "modes/stop_mode.hpp"
+#include "core/params_loader.hpp"
 #include "ros/manual_control_node.hpp"
 
 using namespace autoware::manual_control;
@@ -24,37 +21,15 @@ using namespace autoware::manual_control;
 int main(int argc, char *argv[]) {
   rclcpp::init(argc, argv);
 
-  // Register Modes
-  auto &factory = DriveModeFactory::instance();
-  factory.registerMode(ModeType::PHYSICS,
-                       []() { return std::make_unique<PhysicsDriveMode>(); });
-  factory.registerMode(ModeType::CRUISE,
-                       []() { return std::make_unique<CruiseDriveMode>(); });
-  factory.registerMode(ModeType::STOP,
-                       []() { return std::make_unique<StopDriveMode>(); });
-
   auto node = std::make_shared<ManualControlNode>(OperatorRole::REMOTE);
+  register_default_modes(DriveModeFactory::instance(), *node);
 
-  auto declare = [&](const char *name, const rclcpp::ParameterValue &def) {
-    if (!node->has_parameter(name))
-      node->declare_parameter(name, def);
-  };
-  declare("zenoh_config", rclcpp::ParameterValue(std::string("")));
-  declare("vehicle", rclcpp::ParameterValue(std::string("v1")));
-  declare("arrival_timeout_ms", rclcpp::ParameterValue(500.0));
-  declare("control_rate_hz", rclcpp::ParameterValue(60.0));
-
-  // params-file values may arrive typed as int; read uniformly as double.
-  auto as_double = [&](const char *name) -> double {
-    auto p = node->get_parameter(name);
-    return (p.get_type() == rclcpp::ParameterType::PARAMETER_INTEGER)
-               ? static_cast<double>(p.as_int())
-               : p.as_double();
-  };
-
-  const std::string zenoh_cfg = node->get_parameter("zenoh_config").as_string();
-  const std::string vehicle = node->get_parameter("vehicle").as_string();
-  const double rate_hz = as_double("control_rate_hz");
+  const std::string zenoh_cfg =
+      load_param<std::string>(*node, "zenoh_config", std::string{});
+  const std::string vehicle =
+      load_param<std::string>(*node, "vehicle", std::string{"v1"});
+  const float arrival_timeout_ms =
+      load_float(*node, "arrival_timeout_ms", 500.0f);
 
   zenoh::Config zconf = zenoh_cfg.empty()
                             ? zenoh::Config::create_default()
@@ -64,18 +39,16 @@ int main(int argc, char *argv[]) {
 
   ZenohInputConfig in_cfg;
   in_cfg.intent_key = "manual_control/" + vehicle + "/intent";
-  in_cfg.arrival_timeout_s =
-      static_cast<float>(as_double("arrival_timeout_ms") / 1000.0);
+  in_cfg.arrival_timeout_s = arrival_timeout_ms / 1000.0f;
   ZenohInput input(session, in_cfg);
 
   ZenohTelemetry telemetry(session, input,
                            "manual_control/" + vehicle + "/telemetry");
 
-  RuntimeConfig cfg;
-  cfg.rate_hz = rate_hz;
+  RuntimeConfig cfg = load_runtime_config(*node);
 
   std::fprintf(stderr, "[remote_control] vehicle=%s rate=%.0fHz intent=%s\n",
-               vehicle.c_str(), rate_hz, in_cfg.intent_key.c_str());
+               vehicle.c_str(), cfg.rate_hz, in_cfg.intent_key.c_str());
 
   run_control_runtime(node, input, telemetry, cfg);
 

--- a/src/remote_control.cpp
+++ b/src/remote_control.cpp
@@ -1,0 +1,84 @@
+// Zenoh-driven teleop entry point.
+
+#include <cstdio>
+#include <memory>
+#include <string>
+
+// zenoh.hxx must precede rclcpp to avoid macro/template clashes.
+#include <zenoh.hxx>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "bridge/zenoh/zenoh_input.hpp"
+#include "bridge/zenoh/zenoh_telemetry.hpp"
+#include "common/types.hpp"
+#include "core/control_runtime.hpp"
+#include "core/drive_mode_factory.hpp"
+#include "modes/cruise_mode.hpp"
+#include "modes/physics_mode.hpp"
+#include "modes/stop_mode.hpp"
+#include "ros/manual_control_node.hpp"
+
+using namespace autoware::manual_control;
+
+int main(int argc, char *argv[]) {
+  rclcpp::init(argc, argv);
+
+  // Register Modes
+  auto &factory = DriveModeFactory::instance();
+  factory.registerMode(ModeType::PHYSICS,
+                       []() { return std::make_unique<PhysicsDriveMode>(); });
+  factory.registerMode(ModeType::CRUISE,
+                       []() { return std::make_unique<CruiseDriveMode>(); });
+  factory.registerMode(ModeType::STOP,
+                       []() { return std::make_unique<StopDriveMode>(); });
+
+  auto node = std::make_shared<ManualControlNode>(OperatorRole::REMOTE);
+
+  auto declare = [&](const char *name, const rclcpp::ParameterValue &def) {
+    if (!node->has_parameter(name))
+      node->declare_parameter(name, def);
+  };
+  declare("zenoh_config", rclcpp::ParameterValue(std::string("")));
+  declare("vehicle", rclcpp::ParameterValue(std::string("v1")));
+  declare("arrival_timeout_ms", rclcpp::ParameterValue(500.0));
+  declare("control_rate_hz", rclcpp::ParameterValue(60.0));
+
+  // params-file values may arrive typed as int; read uniformly as double.
+  auto as_double = [&](const char *name) -> double {
+    auto p = node->get_parameter(name);
+    return (p.get_type() == rclcpp::ParameterType::PARAMETER_INTEGER)
+               ? static_cast<double>(p.as_int())
+               : p.as_double();
+  };
+
+  const std::string zenoh_cfg = node->get_parameter("zenoh_config").as_string();
+  const std::string vehicle = node->get_parameter("vehicle").as_string();
+  const double rate_hz = as_double("control_rate_hz");
+
+  zenoh::Config zconf = zenoh_cfg.empty()
+                            ? zenoh::Config::create_default()
+                            : zenoh::Config::from_file(zenoh_cfg.c_str());
+  auto session = std::make_shared<zenoh::Session>(
+      zenoh::Session::open(std::move(zconf)));
+
+  ZenohInputConfig in_cfg;
+  in_cfg.intent_key = "manual_control/" + vehicle + "/intent";
+  in_cfg.arrival_timeout_s =
+      static_cast<float>(as_double("arrival_timeout_ms") / 1000.0);
+  ZenohInput input(session, in_cfg);
+
+  ZenohTelemetry telemetry(session, input,
+                           "manual_control/" + vehicle + "/telemetry");
+
+  RuntimeConfig cfg;
+  cfg.rate_hz = rate_hz;
+
+  std::fprintf(stderr, "[remote_control] vehicle=%s rate=%.0fHz intent=%s\n",
+               vehicle.c_str(), rate_hz, in_cfg.intent_key.c_str());
+
+  run_control_runtime(node, input, telemetry, cfg);
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/ros/manual_control_node.hpp
+++ b/src/ros/manual_control_node.hpp
@@ -11,6 +11,8 @@
 #include <tier4_external_api_msgs/srv/engage.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/manual_operator_heartbeat.hpp>
+#include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
+#include <autoware_adapi_v1_msgs/srv/change_operation_mode.hpp>
 #include <autoware_vehicle_msgs/msg/engage.hpp>
 #include <autoware_vehicle_msgs/msg/gear_report.hpp>
 #include <autoware_vehicle_msgs/msg/velocity_report.hpp>
@@ -21,6 +23,8 @@ using std::placeholders::_1;
 
 using tier4_control_msgs::msg::GateMode;
 using EngageSrv = tier4_external_api_msgs::srv::Engage;
+using ChangeOperationMode = autoware_adapi_v1_msgs::srv::ChangeOperationMode;
+using OperationModeState = autoware_adapi_v1_msgs::msg::OperationModeState;
 using autoware_control_msgs::msg::Control;
 using autoware_vehicle_msgs::msg::GearCommand;
 
@@ -43,7 +47,8 @@ public:
       : Node("ManualControl",
              rclcpp::NodeOptions()
                  .allow_undeclared_parameters(true)
-                 .automatically_declare_parameters_from_overrides(true)) {
+                 .automatically_declare_parameters_from_overrides(true)),
+        role_(role) {
     // Publishers
     pub_gate_mode_ = this->create_publisher<GateMode>(
         "/control/gate_mode_cmd", rclcpp::QoS(1).transient_local());
@@ -85,6 +90,20 @@ public:
     sub_gear_ = this->create_subscription<GearReport>(
         "/vehicle/status/gear_status", 10,
         std::bind(&ManualControlNode::onGear, this, _1));
+
+    // REMOTE operator only: complete the standard Autoware engage handshake.
+    // change_to_remote sets the target but does not engage; watch
+    // operation_mode/state and call enable_autoware_control when the target
+    // is REMOTE but control isn't enabled yet, rate-limited to 2s.
+    if (role_ == OperatorRole::REMOTE) {
+      enable_client_ = this->create_client<ChangeOperationMode>(
+          "/api/operation_mode/enable_autoware_control");
+      rclcpp::QoS qos_state(1);
+      qos_state.transient_local().reliable();
+      sub_op_mode_ = this->create_subscription<OperationModeState>(
+          "/api/operation_mode/state", qos_state,
+          std::bind(&ManualControlNode::onOperationModeState, this, _1));
+    }
 
     init_parameters();
 
@@ -282,6 +301,36 @@ private:
     current_gear_type_ = msg->report;
   }
 
+  void onOperationModeState(const OperationModeState::ConstSharedPtr msg) {
+    if (msg->mode != OperationModeState::REMOTE) return;
+    if (msg->is_autoware_control_enabled) return;
+    if (msg->is_in_transition) return;
+
+    const auto now = std::chrono::steady_clock::now();
+    if (now - last_enable_attempt_ < std::chrono::seconds(2)) return;
+    last_enable_attempt_ = now;
+
+    if (!enable_client_ ||
+        !enable_client_->wait_for_service(std::chrono::milliseconds(100))) {
+      RCLCPP_WARN(this->get_logger(),
+          "enable_autoware_control: service not yet available");
+      return;
+    }
+    auto req = std::make_shared<ChangeOperationMode::Request>();
+    enable_client_->async_send_request(req,
+        [this](rclcpp::Client<ChangeOperationMode>::SharedFuture fut) {
+          auto res = fut.get();
+          if (res && res->status.success) {
+            RCLCPP_INFO(this->get_logger(),
+                "enable_autoware_control: success");
+          } else {
+            RCLCPP_WARN(this->get_logger(),
+                "enable_autoware_control: failed (%s)",
+                res ? res->status.message.c_str() : "null response");
+          }
+        });
+  }
+
   void monitor_state() {
     // 1. Handle Pending External Mode Request (Startup or user intent)
     if (pending_external_request_) {
@@ -311,6 +360,8 @@ private:
     }
   }
 
+  const OperatorRole role_;
+
   rclcpp::Publisher<GateMode>::SharedPtr pub_gate_mode_;
   rclcpp::Client<EngageSrv>::SharedPtr client_engage_;
   rclcpp::Publisher<Control>::SharedPtr pub_control_command_;
@@ -322,6 +373,12 @@ private:
   rclcpp::Subscription<Engage>::SharedPtr sub_engage_;
   rclcpp::Subscription<VelocityReport>::SharedPtr sub_velocity_;
   rclcpp::Subscription<GearReport>::SharedPtr sub_gear_;
+
+  // REMOTE only — completes the engage handshake (enable_autoware_control).
+  rclcpp::Client<ChangeOperationMode>::SharedPtr enable_client_;
+  rclcpp::Subscription<OperationModeState>::SharedPtr sub_op_mode_;
+  std::chrono::steady_clock::time_point last_enable_attempt_ =
+      std::chrono::steady_clock::now() - std::chrono::seconds(60);
 
   rclcpp::TimerBase::SharedPtr monitor_timer_;
   rclcpp::TimerBase::SharedPtr heartbeat_timer_; // REMOTE only

--- a/src/ros/manual_control_node.hpp
+++ b/src/ros/manual_control_node.hpp
@@ -10,6 +10,7 @@
 #include <tier4_control_msgs/msg/gate_mode.hpp>
 #include <tier4_external_api_msgs/srv/engage.hpp>
 
+#include <autoware_adapi_v1_msgs/msg/manual_operator_heartbeat.hpp>
 #include <autoware_vehicle_msgs/msg/engage.hpp>
 #include <autoware_vehicle_msgs/msg/gear_report.hpp>
 #include <autoware_vehicle_msgs/msg/velocity_report.hpp>
@@ -23,6 +24,7 @@ using EngageSrv = tier4_external_api_msgs::srv::Engage;
 using autoware_control_msgs::msg::Control;
 using autoware_vehicle_msgs::msg::GearCommand;
 
+using autoware_adapi_v1_msgs::msg::ManualOperatorHeartbeat;
 using autoware_vehicle_msgs::msg::Engage;
 using autoware_vehicle_msgs::msg::GearReport;
 using autoware_vehicle_msgs::msg::VelocityReport;
@@ -30,9 +32,14 @@ using geometry_msgs::msg::PoseWithCovarianceStamped;
 
 namespace autoware::manual_control {
 
+// LOCAL drives the gate directly (/control/command/control_cmd, no heartbeat);
+// REMOTE feeds external_cmd_selector and heartbeats /external/remote/heartbeat
+// so vehicle_cmd_gate stays live.
+enum class OperatorRole { LOCAL, REMOTE };
+
 class ManualControlNode : public rclcpp::Node {
 public:
-  ManualControlNode()
+  explicit ManualControlNode(OperatorRole role = OperatorRole::LOCAL)
       : Node("ManualControl",
              rclcpp::NodeOptions()
                  .allow_undeclared_parameters(true)
@@ -43,12 +50,27 @@ public:
     client_engage_ = this->create_client<EngageSrv>(
         "/api/autoware/set/engage", rmw_qos_profile_services_default);
 
+    const std::string control_cmd_topic =
+        (role == OperatorRole::REMOTE) ? "/external/selected/control_cmd"
+                                       : "/control/command/control_cmd";
     pub_control_command_ = this->create_publisher<Control>(
-        "/control/command/control_cmd", rclcpp::QoS(1).transient_local());
+        control_cmd_topic, rclcpp::QoS(1).transient_local());
     pub_gear_cmd_ =
         this->create_publisher<GearCommand>("/external/selected/gear_cmd", 1);
     pub_initialpose_ = this->create_publisher<PoseWithCovarianceStamped>(
         "/initialpose", rclcpp::QoS(1));
+
+    // heartbeat (REMOTE only)
+    if (role == OperatorRole::REMOTE) {
+      pub_heartbeat_ = this->create_publisher<ManualOperatorHeartbeat>(
+          "/external/remote/heartbeat", 1);
+      heartbeat_timer_ = this->create_wall_timer(100ms, [this]() {
+        ManualOperatorHeartbeat msg;
+        msg.stamp = this->get_clock()->now();
+        msg.ready = true;
+        pub_heartbeat_->publish(msg);
+      });
+    }
 
     // Subscribers
     sub_gate_mode_ = this->create_subscription<GateMode>(
@@ -294,6 +316,7 @@ private:
   rclcpp::Publisher<Control>::SharedPtr pub_control_command_;
   rclcpp::Publisher<GearCommand>::SharedPtr pub_gear_cmd_;
   rclcpp::Publisher<PoseWithCovarianceStamped>::SharedPtr pub_initialpose_;
+  rclcpp::Publisher<ManualOperatorHeartbeat>::SharedPtr pub_heartbeat_; // REMOTE only
 
   rclcpp::Subscription<GateMode>::SharedPtr sub_gate_mode_;
   rclcpp::Subscription<Engage>::SharedPtr sub_engage_;
@@ -301,6 +324,7 @@ private:
   rclcpp::Subscription<GearReport>::SharedPtr sub_gear_;
 
   rclcpp::TimerBase::SharedPtr monitor_timer_;
+  rclcpp::TimerBase::SharedPtr heartbeat_timer_; // REMOTE only
 
   // Internal State cache
   uint8_t gate_mode_ = GateMode::AUTO;

--- a/src/ros/manual_control_node.hpp
+++ b/src/ros/manual_control_node.hpp
@@ -15,6 +15,7 @@
 #include <autoware_adapi_v1_msgs/srv/change_operation_mode.hpp>
 #include <autoware_vehicle_msgs/msg/engage.hpp>
 #include <autoware_vehicle_msgs/msg/gear_report.hpp>
+#include <autoware_vehicle_msgs/msg/steering_report.hpp>
 #include <autoware_vehicle_msgs/msg/velocity_report.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 
@@ -31,6 +32,7 @@ using autoware_vehicle_msgs::msg::GearCommand;
 using autoware_adapi_v1_msgs::msg::ManualOperatorHeartbeat;
 using autoware_vehicle_msgs::msg::Engage;
 using autoware_vehicle_msgs::msg::GearReport;
+using autoware_vehicle_msgs::msg::SteeringReport;
 using autoware_vehicle_msgs::msg::VelocityReport;
 using geometry_msgs::msg::PoseWithCovarianceStamped;
 
@@ -90,6 +92,9 @@ public:
     sub_gear_ = this->create_subscription<GearReport>(
         "/vehicle/status/gear_status", 10,
         std::bind(&ManualControlNode::onGear, this, _1));
+    sub_steering_ = this->create_subscription<SteeringReport>(
+        "/vehicle/status/steering_status", 1,
+        std::bind(&ManualControlNode::onSteering, this, _1));
 
     // REMOTE operator only: complete the standard Autoware engage handshake.
     // change_to_remote sets the target but does not engage; watch
@@ -121,6 +126,7 @@ public:
   VehicleState get_vehicle_state() const {
     VehicleState s;
     s.velocity = current_velocity_;
+    s.steer_angle = current_steer_angle_;
     // Map ROS gear to Enum
     switch (current_gear_type_) {
     case GearReport::PARK:
@@ -300,6 +306,9 @@ private:
   void onGear(const GearReport::ConstSharedPtr msg) {
     current_gear_type_ = msg->report;
   }
+  void onSteering(const SteeringReport::ConstSharedPtr msg) {
+    current_steer_angle_ = msg->steering_tire_angle;
+  }
 
   void onOperationModeState(const OperationModeState::ConstSharedPtr msg) {
     if (msg->mode != OperationModeState::REMOTE) return;
@@ -373,6 +382,7 @@ private:
   rclcpp::Subscription<Engage>::SharedPtr sub_engage_;
   rclcpp::Subscription<VelocityReport>::SharedPtr sub_velocity_;
   rclcpp::Subscription<GearReport>::SharedPtr sub_gear_;
+  rclcpp::Subscription<SteeringReport>::SharedPtr sub_steering_;
 
   // REMOTE only — completes the engage handshake (enable_autoware_control).
   rclcpp::Client<ChangeOperationMode>::SharedPtr enable_client_;
@@ -388,6 +398,7 @@ private:
   bool current_engage_ = false;
   uint8_t current_gear_type_ = GearReport::PARK;
   double current_velocity_ = 0.0;
+  double current_steer_angle_ = 0.0;
 
   std::vector<std::string> preset_names_;
   int current_preset_index_ = -1;

--- a/src/ui/console_ui.hpp
+++ b/src/ui/console_ui.hpp
@@ -4,7 +4,7 @@
 
 #include "common/types.hpp"
 #include "core/drive_mode_factory.hpp"
-#include "core/mode_manager.hpp"
+#include "core/telemetry.hpp"
 #include "input/input_system.hpp"
 #include <cmath>
 #include <iomanip>
@@ -12,17 +12,18 @@
 
 namespace autoware::manual_control {
 
+// Keyboard TelemetrySink: renders Telemetry to the terminal. The key
+// highlight is read from the InputSystem injected at construction.
 class ConsoleUI {
 public:
+  explicit ConsoleUI(const InputSystem &input) : input_(input) {}
+
   void init() {
     std::cout << "\033[2J\033[1;1H"; // Clear screen
     printHeader();
   }
 
-  void refresh(const InputSystem &input, const ModeManager &manager,
-               const VehicleState &state, const ControlCommand &cmd,
-               ShiftState shiftState, Gear pendingGear,
-               const std::string &info_msg = "") {
+  void publish(const Telemetry &t) {
     // Only refresh at reasonable rate (~10Hz) to avoid flickering
     static int frame = 0;
     if (frame++ % 6 != 0)
@@ -33,8 +34,8 @@ public:
     std::cout << "\033[J"; // Clear everything below
 
     // 1. Info Message (Persistent/Top)
-    if (!info_msg.empty()) {
-      std::cout << info_msg << "\n";
+    if (!t.info.empty()) {
+      std::cout << t.info << "\n";
     }
 
     // 2. Status Line
@@ -54,27 +55,27 @@ public:
       }
     };
 
-    std::string gear_display = gearToString(state.gear);
+    std::string gear_display = gearToString(t.vehicle.gear);
 
     // If shifting, show transition
-    if (shiftState != ShiftState::IDLE) {
-      gear_display += "->" + gearToString(pendingGear);
+    if (t.shift_state != ShiftState::IDLE) {
+      gear_display += "->" + gearToString(t.pending_gear);
     }
 
-    std::cout << "[" << manager.getCurrentModeName() << "] "
+    std::cout << "[" << t.mode << "] "
               << "Gear: " << gear_display << " | ";
 
     // Real Speed & Set Speed (Command) & Steer
     std::cout << "Real: " << std::fixed << std::setprecision(1)
-              << std::abs(state.velocity * 3.6) << " km/hr | ";
+              << std::abs(t.vehicle.velocity * 3.6) << " km/hr | ";
 
-    std::cout << "Set: " << (cmd.velocity * 3.6) << " km/hr | ";
-    std::cout << "Steer: " << std::setprecision(2) << cmd.steer_angle << " rad";
+    std::cout << "Set: " << (t.command.velocity * 3.6) << " km/hr | ";
+    std::cout << "Steer: " << std::setprecision(2) << t.command.steer_angle
+              << " rad";
 
     // Extra Info (Mode specific)
-    std::string status = manager.getStatusString();
-    if (!status.empty()) {
-      std::cout << " | " << status;
+    if (!t.mode_status.empty()) {
+      std::cout << " | " << t.mode_status;
     }
 
     std::cout << " | "; // Separator for Keys
@@ -89,10 +90,10 @@ public:
     };
 
     std::cout << "[";
-    std::cout << getKeyChar(input.isActiveW(), input.isHoldingW(), 'W');
-    std::cout << getKeyChar(input.isActiveA(), input.isHoldingA(), 'A');
-    std::cout << getKeyChar(input.isActiveS(), input.isHoldingS(), 'S');
-    std::cout << getKeyChar(input.isActiveD(), input.isHoldingD(), 'D');
+    std::cout << getKeyChar(input_.isActiveW(), input_.isHoldingW(), 'W');
+    std::cout << getKeyChar(input_.isActiveA(), input_.isHoldingA(), 'A');
+    std::cout << getKeyChar(input_.isActiveS(), input_.isHoldingS(), 'S');
+    std::cout << getKeyChar(input_.isActiveD(), input_.isHoldingD(), 'D');
     std::cout << "]";
 
     std::cout << std::flush;
@@ -129,6 +130,8 @@ private:
     std::cout << "========================================" << std::endl;
     std::cout << "\033[s"; // Save Cursor Position
   }
+
+  const InputSystem &input_;
 };
 
 } // namespace autoware::manual_control

--- a/teleop_config.example.yaml
+++ b/teleop_config.example.yaml
@@ -1,8 +1,45 @@
 /ManualControl:
   ros__parameters:
     start_as_external: false
+
     init_pose:
       presets:
         names: ["origin", "intersection"]
         origin: [0.0, 0.0, 0.0, 0.0]
         intersection: [15.0, 20.0, 0.0, 1.57]
+
+    # Shared control loop
+    control_rate_hz: 60.0
+    shift_stop_tolerance: 0.05    # m/s — speed below which a shift proceeds
+    shift_brake_accel: -10.0      # m/s^2 — override accel while shifting
+
+    # PhysicsDriveMode
+    physics:
+      max_speed: 27.78            # m/s (100 km/h)
+      max_steer: 0.6              # rad
+      steer_rate: 0.8             # rad/s while a steer key is held
+      steer_decay: 1.0            # rad/s auto-center on release
+      steer_deadzone: 0.01        # rad
+      accel_max: 3.5              # m/s^2 at full throttle
+      brake_max: 5.0              # m/s^2 at full brake
+      coast_decel: 2.0            # m/s^2 with no input
+
+    # CruiseDriveMode
+    cruise:
+      max_speed: 27.78
+      steer_rate: 0.3
+      steer_limit: 0.6
+      vel_inc_hold_kph_s: 5.0     # km/h per second when holding throttle
+      vel_dec_hold_kph_s: 10.0    # km/h per second when holding brake
+      accel_p_gain: 3.0
+      max_accel: 5.0
+      min_accel: -10.0
+
+    # StopDriveMode
+    stop:
+      brake_accel: -10.0
+
+    # Remote (Zenoh) entry only — the keyboard entry ignores these.
+    vehicle: "v1"
+    arrival_timeout_ms: 500.0
+    zenoh_config: ""

--- a/teleop_config.example.yaml
+++ b/teleop_config.example.yaml
@@ -23,6 +23,7 @@
       accel_max: 3.5              # m/s^2 at full throttle
       brake_max: 5.0              # m/s^2 at full brake
       coast_decel: 2.0            # m/s^2 with no input
+      max_vel_offset: 3.0         # m/s — setpoint anti-windup ceiling vs real
 
     # CruiseDriveMode
     cruise:


### PR DESCRIPTION
## Summary

Rewrite `autoware_manual_control` as a Zenoh-driven teleop for FMS,
compatible with Autoware 1.5+. A new `remote_control` entry point consumes
intent over Zenoh and publishes telemetry back; `keyboard_control` keeps
working through a shared `ControlLoop` template.

## Changes

- `remote_control` (new): Zenoh intent in / telemetry out; shares the
  `ControlLoop` template with `keyboard_control`.
- `ManualControlNode` is parameterized by an `OperatorRole`, so its
  heartbeat lands on `/external/local/heartbeat` (LOCAL) or
  `/external/remote/heartbeat` (REMOTE) — the topic `external_cmd_selector`
  forwards to `vehicle_cmd_gate`.
- New transport/core modules: `bridge/zenoh/{zenoh_input,zenoh_telemetry}.hpp`,
  `core/{control_loop,telemetry}.hpp`; `bridge/ros/autoware_bridge.hpp`
  (moved/renamed).
- `keyboard_control` slimmed onto the shared loop; `physics_mode` reworked.
- Steering follows the Autoware/Carla positive-left convention (A → +1,
  D → -1).
- Runtime `teleop_config.yaml` is untracked; deployments seed from
  `teleop_config.example.yaml` on first run.
- `CMakeLists.txt` / `package.xml` updated for the new layout.

## Notes

Pairs with the fms control-plane Zenoh PR (`pr/teleop-zenoh-plane`).