### PR TITLE
refactor+fix: teleop control core

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,6 +17,8 @@ services:
       - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
       - REMOTE_PASSWORD=o
       - USE_SIM_TIME=false
+    extra_hosts:
+      - "${HOSTNAME:-localhost}:127.0.0.1"
 
   teleop:
     network_mode: host

--- a/run_containers.sh
+++ b/run_containers.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Export HOSTNAME so compose can expand ${HOSTNAME} in extra_hosts.
+export HOSTNAME="${HOSTNAME:-$(hostname)}"
+
 # Color definitions
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'

--- a/src/core/control_runtime.hpp
+++ b/src/core/control_runtime.hpp
@@ -1,0 +1,133 @@
+#ifndef TELEOP_CONTROL_RUNTIME_HPP
+#define TELEOP_CONTROL_RUNTIME_HPP
+
+// Shared 60Hz control loop, generic over an input source and a telemetry sink.
+
+#include "common/types.hpp"
+#include "core/mode_manager.hpp"
+#include "core/telemetry.hpp"
+#include "ros/manual_control_node.hpp"
+
+#include <chrono>
+#include <cmath>
+#include <memory>
+
+#include <rclcpp/rclcpp.hpp>
+
+namespace autoware::manual_control {
+
+struct RuntimeConfig {
+  double rate_hz = 60.0;
+  float shift_stop_tolerance = 0.05f; // m/s — speed below which a shift proceeds
+};
+
+// InputSource: InputState update(). TelemetrySink: void publish(Telemetry). On
+// stale input, update() returns a braking InputState (throttle 0, brake 1) so
+// the loop needs no special case.
+template <typename InputSource, typename TelemetrySink>
+void run_control_runtime(std::shared_ptr<ManualControlNode> node,
+                         InputSource &input, TelemetrySink &sink,
+                         const RuntimeConfig &cfg) {
+  ModeManager mode_manager;
+
+  if (node->should_start_external()) {
+    node->force_external_mode();
+  }
+
+  rclcpp::Rate rate(cfg.rate_hz);
+  auto last_time = std::chrono::steady_clock::now();
+
+  ShiftState shift_state = ShiftState::IDLE;
+  Gear pending_gear = Gear::PARK;
+
+  bool running = true;
+  while (rclcpp::ok() && running) {
+    auto now = std::chrono::steady_clock::now();
+    std::chrono::duration<float> dt_duration = now - last_time;
+    last_time = now;
+    float dt = dt_duration.count();
+    if (dt > 0.1f)
+      dt = 0.1f;
+
+    InputState input_state = input.update();
+
+    if (input_state.quit)
+      running = false;
+
+    if (input_state.toggle_auto) {
+      node->toggle_manual_control();
+    }
+
+    if (input_state.reset_pose) {
+      node->reset_initial_pose();
+    }
+
+    VehicleState vehicle_state = node->get_vehicle_state();
+
+    // Shift request: brake to a stop, shift, then resume (stop-wait-shift).
+    if (input_state.shift_drive && vehicle_state.gear != Gear::DRIVE) {
+      pending_gear = Gear::DRIVE;
+      shift_state = ShiftState::STOPPING;
+    }
+    if (input_state.shift_reverse && vehicle_state.gear != Gear::REVERSE) {
+      pending_gear = Gear::REVERSE;
+      shift_state = ShiftState::STOPPING;
+    }
+    if (input_state.shift_park && vehicle_state.gear != Gear::PARK) {
+      pending_gear = Gear::PARK;
+      shift_state = ShiftState::STOPPING;
+    }
+
+    bool override_control = false;
+    ControlCommand override_cmd;
+
+    if (shift_state == ShiftState::STOPPING) {
+      override_control = true;
+      override_cmd.velocity = 0.0f;
+      override_cmd.acceleration = -10.0f;
+      override_cmd.steer_angle = vehicle_state.steer_angle;
+
+      if (std::abs(vehicle_state.velocity) < cfg.shift_stop_tolerance) {
+        node->set_target_gear(pending_gear);
+        shift_state = ShiftState::SHIFTING;
+      }
+    } else if (shift_state == ShiftState::SHIFTING) {
+      override_control = true;
+      override_cmd.velocity = 0.0f;
+      override_cmd.acceleration = -10.0f;
+      override_cmd.steer_angle = vehicle_state.steer_angle;
+
+      if (vehicle_state.gear == pending_gear) {
+        mode_manager.reinit(vehicle_state);
+        shift_state = ShiftState::IDLE;
+        override_control = false;
+      }
+    }
+
+    mode_manager.update(dt, input_state, vehicle_state);
+    ControlCommand cmd = mode_manager.getCommand();
+
+    if (override_control) {
+      cmd = override_cmd;
+    }
+
+    node->publish_command(cmd);
+
+    Telemetry t;
+    t.mode = mode_manager.getCurrentModeName();
+    t.mode_status = mode_manager.getStatusString();
+    t.vehicle = vehicle_state;
+    t.command = cmd;
+    t.shift_state = shift_state;
+    t.pending_gear = pending_gear;
+    t.info = node->get_info_message();
+    sink.publish(t);
+
+    rclcpp::spin_some(node);
+    rate.sleep();
+  }
+}
+
+} // namespace autoware::manual_control
+
+#endif // TELEOP_CONTROL_RUNTIME_HPP

--- a/src/core/telemetry.hpp
+++ b/src/core/telemetry.hpp
@@ -1,0 +1,23 @@
+#ifndef TELEOP_TELEMETRY_HPP
+#define TELEOP_TELEMETRY_HPP
+
+#include "common/types.hpp"
+
+#include <string>
+
+namespace autoware::manual_control {
+
+// Per-tick control snapshot for the telemetry sink.
+struct Telemetry {
+  std::string mode;
+  std::string mode_status;
+  VehicleState vehicle;   // measured
+  ControlCommand command; // commanded this tick
+  ShiftState shift_state = ShiftState::IDLE;
+  Gear pending_gear = Gear::NONE;
+  std::string info;
+};
+
+} // namespace autoware::manual_control
+
+#endif // TELEOP_TELEMETRY_HPP

--- a/src/input/input_system.hpp
+++ b/src/input/input_system.hpp
@@ -137,6 +137,15 @@ public:
     state.brake_hold = key_s_.is_holding_state();
     state.steer_dir = (a ? 1 : 0) + (d ? -1 : 0); // Left is +
 
+    // Drop held continuous inputs on auto/local toggle so the new mode
+    // starts from a fresh release.
+    if (state.toggle_auto) {
+      key_w_.reset();
+      key_s_.reset();
+      key_a_.reset();
+      key_d_.reset();
+    }
+
     return state;
   }
 

--- a/src/keyboard_control.cpp
+++ b/src/keyboard_control.cpp
@@ -1,9 +1,11 @@
-#include <chrono>
+// Standalone keyboard teleop entry point.
+
 #include <memory>
+
 #include <rclcpp/rclcpp.hpp>
-#include <thread>
 
 #include "common/types.hpp"
+#include "core/control_runtime.hpp"
 #include "core/drive_mode_factory.hpp"
 #include "core/mode_manager.hpp"
 #include "input/input_system.hpp"
@@ -13,134 +15,27 @@
 #include "ros/manual_control_node.hpp"
 #include "ui/console_ui.hpp"
 
+using namespace autoware::manual_control;
+
 int main(int argc, char *argv[]) {
   rclcpp::init(argc, argv);
 
-  // 1. Initialize Components
-  // Register Modes
-  auto &factory = autoware::manual_control::DriveModeFactory::instance();
-  factory.registerMode(ModeType::PHYSICS, []() {
-    return std::make_unique<autoware::manual_control::PhysicsDriveMode>();
-  });
-  factory.registerMode(ModeType::CRUISE, []() {
-    return std::make_unique<autoware::manual_control::CruiseDriveMode>();
-  });
-  factory.registerMode(ModeType::STOP, []() {
-    return std::make_unique<autoware::manual_control::StopDriveMode>();
-  });
+  auto &factory = DriveModeFactory::instance();
+  factory.registerMode(ModeType::PHYSICS,
+                       []() { return std::make_unique<PhysicsDriveMode>(); });
+  factory.registerMode(ModeType::CRUISE,
+                       []() { return std::make_unique<CruiseDriveMode>(); });
+  factory.registerMode(ModeType::STOP,
+                       []() { return std::make_unique<StopDriveMode>(); });
 
-  auto node = std::make_shared<autoware::manual_control::ManualControlNode>();
-  autoware::manual_control::InputSystem input_system;
-  autoware::manual_control::ModeManager mode_manager;
-  autoware::manual_control::ConsoleUI ui;
+  auto node = std::make_shared<ManualControlNode>();
+  InputSystem input_system;
+  ConsoleUI ui(input_system);
 
-  // 2. Setup
-  ui.init(); // 3. Main Loop
-  if (node->should_start_external()) {
-    node->force_external_mode();
-  }
+  ui.init();
 
-  rclcpp::Rate rate(60);
-  auto last_time = std::chrono::steady_clock::now();
-
-  // Shift Safety State
-  ShiftState shift_state = ShiftState::IDLE;
-  Gear pending_gear = Gear::PARK;
-
-  bool running = true;
-  while (rclcpp::ok() && running) {
-    auto now = std::chrono::steady_clock::now();
-    std::chrono::duration<float> dt_duration = now - last_time;
-    last_time = now;
-    float dt = dt_duration.count();
-    if (dt > 0.1f)
-      dt = 0.1f; // Cap max dt
-
-    // --- Input Phase ---
-    InputState input = input_system.update();
-
-    if (input.quit)
-      running = false;
-
-    // --- Logic Phase ---
-
-    if (input.toggle_auto) {
-      node->toggle_manual_control();
-      // Reset input state on toggle
-      input_system.reset();
-    }
-
-    if (input.reset_pose) {
-      node->reset_initial_pose();
-    }
-
-    // Get Vehicle State early for logic checks
-    VehicleState vehicle_state = node->get_vehicle_state();
-
-    // Shift Request Handling (Stop-Wait-Shift)
-    if (input.shift_drive && vehicle_state.gear != Gear::DRIVE) {
-      pending_gear = Gear::DRIVE;
-      shift_state = ShiftState::STOPPING;
-    }
-    if (input.shift_reverse && vehicle_state.gear != Gear::REVERSE) {
-      pending_gear = Gear::REVERSE;
-      shift_state = ShiftState::STOPPING;
-    }
-    if (input.shift_park && vehicle_state.gear != Gear::PARK) {
-      pending_gear = Gear::PARK;
-      shift_state = ShiftState::STOPPING;
-    }
-
-    bool override_control = false;
-    ControlCommand override_cmd;
-
-    // State Machine
-    if (shift_state == ShiftState::STOPPING) {
-      override_control = true;
-      override_cmd.velocity = 0.0f;
-      override_cmd.acceleration = -10.0f; // Max Brake
-      override_cmd.steer_angle = vehicle_state.steer_angle;
-
-      // Wait for Stop (0.05 m/s tolerance)
-      if (std::abs(vehicle_state.velocity) < 0.05f) {
-        node->set_target_gear(pending_gear);
-        shift_state = ShiftState::SHIFTING;
-      }
-    } else if (shift_state == ShiftState::SHIFTING) {
-      override_control = true;
-      override_cmd.velocity = 0.0f;
-      override_cmd.acceleration = -10.0f; // Hold Brake
-      override_cmd.steer_angle = vehicle_state.steer_angle;
-
-      // Wait for Gear Confirmation
-      if (vehicle_state.gear == pending_gear) {
-        mode_manager.reinit(vehicle_state);
-        shift_state = ShiftState::IDLE;
-        override_control = false;
-      }
-    }
-
-    // Get Vehicle State (Already retrieved above)
-
-    // Update Mode Manager
-    mode_manager.update(dt, input, vehicle_state);
-    ControlCommand cmd = mode_manager.getCommand();
-
-    if (override_control) {
-      cmd = override_cmd;
-    }
-
-    // --- Output Phase ---
-    node->publish_command(cmd);
-
-    // --- UI Phase ---
-    ui.refresh(input_system, mode_manager, vehicle_state, cmd, shift_state,
-               pending_gear, node->get_info_message());
-
-    // ROS Spin
-    rclcpp::spin_some(node);
-    rate.sleep();
-  }
+  RuntimeConfig cfg;
+  run_control_runtime(node, input_system, ui, cfg);
 
   rclcpp::shutdown();
   return 0;

--- a/src/modes/physics_mode.hpp
+++ b/src/modes/physics_mode.hpp
@@ -9,106 +9,79 @@
 
 namespace autoware::manual_control {
 
-// ==========================================
-// Physics Mode: Inertia-based control
-// ==========================================
 class PhysicsDriveMode : public DriveMode {
 public:
-  void onEnter(const VehicleState &current_state) override {
-    // Always start with absolute speed concept
-    current_vel_ = std::abs(current_state.velocity); // seamless handover
-    current_steer_ = current_state.steer_angle;
-    current_accel_ = 0.0f;
-    current_accel_rate_ = 0.0f;
-    last_gear_ = current_state.gear;
+  struct Params {
+    float max_speed = 27.78f;       // m/s (100 km/h)
+    float max_steer = 0.6f;         // rad
+    float steer_rate = 0.8f;        // rad/s while a steer key is held
+    float steer_decay = 1.0f;       // rad/s auto-center on release
+    float steer_deadzone = 0.01f;   // rad
+    float accel_max = 3.5f;         // m/s^2 at full throttle
+    float brake_max = 5.0f;         // m/s^2 at full brake
+    float coast_decel = 2.0f;       // m/s^2 with no input (engine braking)
+    float max_vel_offset = 3.0f;    // m/s — setpoint may lead real by this much
+  };
+
+  PhysicsDriveMode() : PhysicsDriveMode(Params{}) {}
+  explicit PhysicsDriveMode(const Params &params) : params_(params) {}
+
+  void onEnter(const VehicleState &state) override {
+    desired_vel_ = std::abs(state.velocity);
+    current_steer_ = state.steer_angle;
+    last_gear_ = state.gear;
+    status_accel_ = 0.0f;
   }
 
   ControlCommand update(float dt, const InputState &input,
                         const VehicleState &vehicle_state) override {
-
-    // Safety: Reset State on Gear Change
+    // Wipe the setpoint on gear change so speed isn't carried across a reverse.
     if (vehicle_state.gear != last_gear_) {
-      current_vel_ = 0.0f;
-      current_accel_ = 0.0f;
-      current_accel_rate_ = 0.0f;
+      desired_vel_ = 0.0f;
       last_gear_ = vehicle_state.gear;
     }
 
-    // 1. Steering Physics (Attack/Decay)
     if (input.steer_dir != 0) {
-      current_steer_ += input.steer_dir * params_.steer_attack * dt;
-    } else {
-      // Auto-center
-      if (current_steer_ > params_.steer_deadzone) {
-        current_steer_ -= params_.steer_decay * dt;
-        if (current_steer_ < 0)
-          current_steer_ = 0;
-      } else if (current_steer_ < -params_.steer_deadzone) {
-        current_steer_ += params_.steer_decay * dt;
-        if (current_steer_ > 0)
-          current_steer_ = 0;
+      current_steer_ += input.steer_dir * params_.steer_rate * dt;
+    } else if (std::abs(current_steer_) > params_.steer_deadzone) {
+      float step = params_.steer_decay * dt;
+      if (current_steer_ > 0) {
+        current_steer_ = std::max(0.0f, current_steer_ - step);
       } else {
-        current_steer_ = 0;
+        current_steer_ = std::min(0.0f, current_steer_ + step);
       }
+    } else {
+      current_steer_ = 0.0f;
     }
     current_steer_ =
         std::clamp(current_steer_, -params_.max_steer, params_.max_steer);
 
-    // 2. Velocity Physics (Magnitude Based)
-    float real_speed_mag = std::abs(vehicle_state.velocity);
-
-    // Acceleration Ramp
-    if (input.throttle > 0) {
-      current_accel_rate_ = std::min(current_accel_rate_ + 1.0f, 9.0f);
+    float desired_accel;
+    if (input.throttle > 0.0f) {
+      desired_accel = input.throttle * params_.accel_max;
+    } else if (input.brake > 0.0f) {
+      desired_accel = -input.brake * params_.brake_max;
     } else {
-      current_accel_rate_ = 0.0f;
-      // Anti-ghosting: Check if Target (Magnitude) >> Real (Magnitude)
-      // If we are commanding 5.0, but real is 0.0, and throttle released ->
-      // snap
-      if (current_vel_ > real_speed_mag + 2.0f) {
-        current_vel_ = real_speed_mag + 0.5f;
-      }
+      desired_accel = -params_.coast_decel;
     }
 
-    // Apply Acceleration (Increase Magnitude)
-    current_vel_ += (input.throttle > 0 ? current_accel_rate_ : 0.0f) * dt;
+    // Bound the setpoint to real speed so it can't wind up arbitrarily far off.
+    desired_vel_ += desired_accel * dt;
+    desired_vel_ = std::min(desired_vel_,
+                            std::abs(vehicle_state.velocity) + params_.max_vel_offset);
+    desired_vel_ = std::clamp(desired_vel_, 0.0f, params_.max_speed);
 
-    // Apply Braking (Decrease Magnitude)
-    if (input.brake > 0) {
-      // Linear decrease
-      if (current_vel_ > 0) {
-        current_vel_ -= params_.brake_rate * dt;
-        if (current_vel_ < 0)
-          current_vel_ = 0;
-      }
-    }
-
-    // Apply Friction (Decrease Magnitude)
-    float friction = params_.friction_rate;
-    if (vehicle_state.gear == Gear::PARK)
-      friction = 10.0f;
-
-    if (current_vel_ > 0) {
-      current_vel_ -= friction * dt;
-      if (current_vel_ < 0)
-        current_vel_ = 0;
-    }
-
-    current_vel_ = std::clamp(current_vel_, 0.0f, params_.max_speed);
-
-    // Calculate Acceleration Command (Derivative)
-    // Calculated based on speed magnitude to prevent sign flip instability
-    // during direction changes
-    float accel_cmd = 0.0f;
-    if (dt > 1e-4) {
-      accel_cmd = (current_vel_ - real_speed_mag) / dt;
+    // Drop only positive intent at max_speed; keep negative so braking holds.
+    float realized_accel = desired_accel;
+    if (desired_vel_ >= params_.max_speed && realized_accel > 0.0f) {
+      realized_accel = 0.0f;
     }
 
     ControlCommand cmd;
-    cmd.velocity = current_vel_;
-    cmd.acceleration = accel_cmd;
+    cmd.velocity = desired_vel_;
+    cmd.acceleration = realized_accel;
     cmd.steer_angle = current_steer_;
-
+    status_accel_ = realized_accel;
     return cmd;
   }
 
@@ -116,27 +89,16 @@ public:
 
   std::string getStatusString() const override {
     char buf[64];
-    snprintf(buf, sizeof(buf), "Acc: %.2f m/s2", current_accel_);
+    std::snprintf(buf, sizeof(buf), "Acc: %.2f m/s2", status_accel_);
     return std::string(buf);
   }
 
 private:
-  // We track Magnitude (Speed) here, assumed positive
-  float current_vel_ = 0.0f;
+  Params params_;
+  float desired_vel_ = 0.0f;
   float current_steer_ = 0.0f;
-  float current_accel_ = 0.0f;
-  float current_accel_rate_ = 0.0f;
+  float status_accel_ = 0.0f;
   Gear last_gear_ = Gear::PARK;
-
-  struct Params {
-    float max_speed = 27.78f;
-    float max_steer = 0.6f;
-    float steer_attack = 0.8f;
-    float steer_decay = 1.0f;
-    float steer_deadzone = 0.01f;
-    float brake_rate = 10.0f;
-    float friction_rate = 3.0f;
-  } params_;
 };
 
 } // namespace autoware::manual_control

--- a/src/ros/manual_control_node.hpp
+++ b/src/ros/manual_control_node.hpp
@@ -12,6 +12,7 @@
 
 #include <autoware_vehicle_msgs/msg/engage.hpp>
 #include <autoware_vehicle_msgs/msg/gear_report.hpp>
+#include <autoware_vehicle_msgs/msg/steering_report.hpp>
 #include <autoware_vehicle_msgs/msg/velocity_report.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 
@@ -25,6 +26,7 @@ using autoware_vehicle_msgs::msg::GearCommand;
 
 using autoware_vehicle_msgs::msg::Engage;
 using autoware_vehicle_msgs::msg::GearReport;
+using autoware_vehicle_msgs::msg::SteeringReport;
 using autoware_vehicle_msgs::msg::VelocityReport;
 using geometry_msgs::msg::PoseWithCovarianceStamped;
 
@@ -63,6 +65,9 @@ public:
     sub_gear_ = this->create_subscription<GearReport>(
         "/vehicle/status/gear_status", 10,
         std::bind(&ManualControlNode::onGear, this, _1));
+    sub_steering_ = this->create_subscription<SteeringReport>(
+        "/vehicle/status/steering_status", 1,
+        std::bind(&ManualControlNode::onSteering, this, _1));
 
     init_parameters();
 
@@ -80,6 +85,7 @@ public:
   VehicleState get_vehicle_state() const {
     VehicleState s;
     s.velocity = current_velocity_;
+    s.steer_angle = current_steer_angle_;
     // Map ROS gear to Enum
     switch (current_gear_type_) {
     case GearReport::PARK:
@@ -259,6 +265,9 @@ private:
   void onGear(const GearReport::ConstSharedPtr msg) {
     current_gear_type_ = msg->report;
   }
+  void onSteering(const SteeringReport::ConstSharedPtr msg) {
+    current_steer_angle_ = msg->steering_tire_angle;
+  }
 
   void monitor_state() {
     // 1. Handle Pending External Mode Request (Startup or user intent)
@@ -299,6 +308,7 @@ private:
   rclcpp::Subscription<Engage>::SharedPtr sub_engage_;
   rclcpp::Subscription<VelocityReport>::SharedPtr sub_velocity_;
   rclcpp::Subscription<GearReport>::SharedPtr sub_gear_;
+  rclcpp::Subscription<SteeringReport>::SharedPtr sub_steering_;
 
   rclcpp::TimerBase::SharedPtr monitor_timer_;
 
@@ -307,6 +317,7 @@ private:
   bool current_engage_ = false;
   uint8_t current_gear_type_ = GearReport::PARK;
   double current_velocity_ = 0.0;
+  double current_steer_angle_ = 0.0;
 
   std::vector<std::string> preset_names_;
   int current_preset_index_ = -1;

--- a/src/ui/console_ui.hpp
+++ b/src/ui/console_ui.hpp
@@ -4,7 +4,7 @@
 
 #include "common/types.hpp"
 #include "core/drive_mode_factory.hpp"
-#include "core/mode_manager.hpp"
+#include "core/telemetry.hpp"
 #include "input/input_system.hpp"
 #include <cmath>
 #include <iomanip>
@@ -12,17 +12,18 @@
 
 namespace autoware::manual_control {
 
+// Keyboard TelemetrySink: renders Telemetry to the terminal. The key
+// highlight is read from the InputSystem injected at construction.
 class ConsoleUI {
 public:
+  explicit ConsoleUI(const InputSystem &input) : input(input) {}
+
   void init() {
     std::cout << "\033[2J\033[1;1H"; // Clear screen
     printHeader();
   }
 
-  void refresh(const InputSystem &input, const ModeManager &manager,
-               const VehicleState &state, const ControlCommand &cmd,
-               ShiftState shiftState, Gear pendingGear,
-               const std::string &info_msg = "") {
+  void publish(const Telemetry &t) {
     // Only refresh at reasonable rate (~10Hz) to avoid flickering
     static int frame = 0;
     if (frame++ % 6 != 0)
@@ -33,8 +34,8 @@ public:
     std::cout << "\033[J"; // Clear everything below
 
     // 1. Info Message (Persistent/Top)
-    if (!info_msg.empty()) {
-      std::cout << info_msg << "\n";
+    if (!t.info.empty()) {
+      std::cout << t.info << "\n";
     }
 
     // 2. Status Line
@@ -54,27 +55,27 @@ public:
       }
     };
 
-    std::string gear_display = gearToString(state.gear);
+    std::string gear_display = gearToString(t.vehicle.gear);
 
     // If shifting, show transition
-    if (shiftState != ShiftState::IDLE) {
-      gear_display += "->" + gearToString(pendingGear);
+    if (t.shift_state != ShiftState::IDLE) {
+      gear_display += "->" + gearToString(t.pending_gear);
     }
 
-    std::cout << "[" << manager.getCurrentModeName() << "] "
+    std::cout << "[" << t.mode << "] "
               << "Gear: " << gear_display << " | ";
 
     // Real Speed & Set Speed (Command) & Steer
     std::cout << "Real: " << std::fixed << std::setprecision(1)
-              << std::abs(state.velocity * 3.6) << " km/hr | ";
+              << std::abs(t.vehicle.velocity * 3.6) << " km/hr | ";
 
-    std::cout << "Set: " << (cmd.velocity * 3.6) << " km/hr | ";
-    std::cout << "Steer: " << std::setprecision(2) << cmd.steer_angle << " rad";
+    std::cout << "Set: " << (t.command.velocity * 3.6) << " km/hr | ";
+    std::cout << "Steer: " << std::setprecision(2) << t.command.steer_angle
+              << " rad";
 
     // Extra Info (Mode specific)
-    std::string status = manager.getStatusString();
-    if (!status.empty()) {
-      std::cout << " | " << status;
+    if (!t.mode_status.empty()) {
+      std::cout << " | " << t.mode_status;
     }
 
     std::cout << " | "; // Separator for Keys
@@ -129,6 +130,8 @@ private:
     std::cout << "========================================" << std::endl;
     std::cout << "\033[s"; // Save Cursor Position
   }
+
+  const InputSystem &input;
 };
 
 } // namespace autoware::manual_control


### PR DESCRIPTION
## Summary

Extracts the keyboard teleop's hand-rolled 60 Hz drive loop into a small, reusable control runtime, and fixes two control bugs (a throttle oscillation and dead steering feedback) plus a docker start-up hiccup. Pure refactor + bug fixes — no behaviour change beyond the two fixes. Four commits, reviewable one at a time.

## Commits
### 1. `refactor: extract shared 60Hz control runtime`

The drive loop (rate limiting, shift/stop handling, mode update -> command -> telemetry) lived inline in `keyboard_control.cpp`. Pull it into `core/control_runtime.hpp`, templated on an input source (anything exposing `InputState update()`) and a telemetry sink (anything exposing `void publish(const Telemetry&)`) — compile-time bound, no virtual interface, zero-cost at the known call sites. `ConsoleUI` is the keyboard's sink; the entry point just wires the two. Decouples the drive loop from keyboard-specific IO.

### 2. `fix(physics): bound the velocity setpoint to real speed (anti-windup)`

Replace physics mode's velocity-ramp law (and its ad-hoc anti-ghosting snap) with a direct input -> acceleration mapping, and bound the velocity setpoint so it leads real speed by at most `max_vel_offset`. Without the bound the setpoint can wind up arbitrarily far from actual speed, so the command stops reflecting reality.

### 3. `fix(vehicle): wire /vehicle/status/steering_status into VehicleState`

The node never subscribed to steering feedback, so `VehicleState.steer_angle` was always `0` and steering-aware UI/telemetry showed a flat real value regardless of the actual wheel angle. Subscribe to `/vehicle/status/steering_status` and populate it in `get_vehicle_state()`.

### 4. `fix(docker): make visualizer resilient to host hostname resolution`

With `network_mode: host` the visualizer container inherits the host hostname but has no matching `/etc/hosts` entry. On a host whose hostname is not itself resolvable (no entry in `/etc/hosts`), TigerVNC fails to resolve it and the service does not come up. Add an `extra_hosts` mapping (`${HOSTNAME}:127.0.0.1`) and export `HOSTNAME` from `run_containers.sh` so compose can expand it.

## Verification

- `colcon build` — clean; produces the `keyboard_control` executable.
- Use `./run_containers.sh up` and `./run_teleop.sh` to try manual control (driving) in Rviz.