### PR TITLE
feat: add a Zenoh remote-operator transport zenoh_control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,28 +5,47 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-# find dependencies
+option(TELEOP_WITH_KEYBOARD "Build keyboard_control" ON)
+option(TELEOP_WITH_ZENOH "Build zenoh_control" OFF)
+
 find_package(ament_cmake REQUIRED)
-# uncomment the following section in order to fill in
-# further dependencies manually.
-# find_package(<dependency> REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(autoware_control_msgs)
 find_package(autoware_vehicle_msgs)
 find_package(autoware_adapi_v1_msgs)
 find_package(geometry_msgs)
 
-add_executable(keyboard_control src/keyboard_control.cpp src/core/drive_mode_factory.cpp)
-target_include_directories(keyboard_control PRIVATE src)
-ament_target_dependencies(keyboard_control rclcpp
-                                           autoware_control_msgs
-                                           autoware_vehicle_msgs
-                                           autoware_adapi_v1_msgs
-                                           geometry_msgs)
+set(COMMON_ROS_DEPS rclcpp autoware_control_msgs autoware_vehicle_msgs
+                    autoware_adapi_v1_msgs geometry_msgs)
 
-install(TARGETS
-  keyboard_control
-  DESTINATION lib/${PROJECT_NAME})
+if(TELEOP_WITH_KEYBOARD)
+  add_executable(keyboard_control src/keyboard_control.cpp src/core/drive_mode_factory.cpp)
+  target_include_directories(keyboard_control PRIVATE src)
+  ament_target_dependencies(keyboard_control ${COMMON_ROS_DEPS})
+  install(TARGETS keyboard_control DESTINATION lib/${PROJECT_NAME})
+endif()
+
+if(TELEOP_WITH_ZENOH)
+  find_package(nlohmann_json REQUIRED)
+  set(ZENOH_VENDOR_PREFIX "$ENV{ZENOH_VENDOR_PREFIX}"
+      CACHE PATH "Path to zenoh vendor from rmw_zenoh build")
+  if(ZENOH_VENDOR_PREFIX)
+    find_package(zenohc REQUIRED PATHS "${ZENOH_VENDOR_PREFIX}/lib/cmake" NO_DEFAULT_PATH)
+    find_package(zenohcxx REQUIRED PATHS "${ZENOH_VENDOR_PREFIX}/lib/cmake" NO_DEFAULT_PATH)
+  else()
+    find_package(zenohc REQUIRED)
+    find_package(zenohcxx REQUIRED)
+  endif()
+  add_executable(zenoh_control src/zenoh_control.cpp src/core/drive_mode_factory.cpp)
+  target_include_directories(zenoh_control PRIVATE src)
+  ament_target_dependencies(zenoh_control ${COMMON_ROS_DEPS})
+  target_link_libraries(zenoh_control nlohmann_json::nlohmann_json zenohcxx::zenohc)
+  install(TARGETS zenoh_control DESTINATION lib/${PROJECT_NAME})
+endif()
+
+if(NOT TELEOP_WITH_KEYBOARD AND NOT TELEOP_WITH_ZENOH)
+  message(WARNING "No entry point selected; set TELEOP_WITH_KEYBOARD or TELEOP_WITH_ZENOH")
+endif()
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ ros2 run autoware_manual_control zenoh_control --ros-args --params-file teleop_c
 
 #### Remote interface
 
-`zenoh_control` has no local keyboard — it is driven by a remote operator client over Zenoh. It subscribes operator intent on `manual_control/<vehicle>/intent` and publishes vehicle telemetry on `manual_control/<vehicle>/telemetry`; both payloads are JSON.
+`zenoh_control` has no local keyboard — it is driven by a remote operator client over Zenoh. It subscribes operator intent on `manual_control/<scope>/intent` and publishes vehicle telemetry on `manual_control/<scope>/telemetry`; both payloads are JSON.
 
 Intent (client → node), one object per control tick:
 

--- a/README.md
+++ b/README.md
@@ -159,12 +159,22 @@ To enable the network transport (`zenoh_control`) for remote driving over Zenoh,
   sudo apt-get install nlohmann-json3-dev
   ```
 - **Zenoh C/C++ SDK** (`zenohc` and `zenohcxx`):
-  - **Option A (Via rmw_zenoh workspace)**: If you build from a workspace that uses `rmw_zenoh`, the Zenoh vendor files are already bundled. You can export the path to this vendor prefix:
+  - **Option A (Recommended, via apt)**: On Ubuntu, set up the official Eclipse Zenoh apt repository first, then install the pre-built libraries (see [zenoh-cpp-example](https://github.com/evshary/zenoh-cpp-example#option-1-install-packages-via-apt-ubuntu) or official documentation):
+    ```bash
+    # Add the Zenoh GPG Key
+    curl -L https://download.eclipse.org/zenoh/debian-repo/zenoh-public-key | sudo gpg --dearmor --yes --output /etc/apt/keyrings/zenoh-public-key.gpg
+    # Add the Repository to Sources
+    echo "deb [signed-by=/etc/apt/keyrings/zenoh-public-key.gpg] https://download.eclipse.org/zenoh/debian-repo/ /" | sudo tee /etc/apt/sources.list.d/zenoh.list > /dev/null
+    # Update and Install
+    sudo apt update
+    sudo apt install libzenohcpp-dev libzenohc-dev
+    ```
+    Install a Zenoh 1.x release matching the `rmw_zenoh` / remote peer you connect to, otherwise the endpoints won't discover each other.
+  - **Option B (Via rmw_zenoh workspace)**: If you build from a workspace that uses `rmw_zenoh`, the Zenoh vendor files are already bundled. You can export the path to this vendor prefix:
     ```bash
     export ZENOH_VENDOR_PREFIX="/path/to/rmw_zenoh_ws/install/zenoh_cpp_vendor/opt/zenoh_cpp_vendor"
     export LD_LIBRARY_PATH="${ZENOH_VENDOR_PREFIX}/lib:${LD_LIBRARY_PATH:-}"
     ```
-  - **Option B (System Installation)**: Refer to the [eclipse-zenoh/zenoh-cpp](https://github.com/eclipse-zenoh/zenoh-cpp) repository to build and install `zenohc` and `zenohcxx` to your system paths.
 
 #### Compilation
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ docker run --rm -it --net=host \
 `TELEOP_IMAGE` can be overridden to point at a fork's CI build (e.g.
 `TELEOP_IMAGE=ghcr.io/<your-fork>/autoware_manual_control:<tag>`).
 
----
-
 ## 🕹️ Operation Guide
 
 ### 1. Driving Checklist
@@ -91,8 +89,6 @@ Modes are config-selected plugins; the active set and cycle order come from the 
 
 All per-mode tuning lives in the config (see below).
 
----
-
 ## ⚙️ Configuration
 
 Behavior is customized via `teleop_config.yaml`; a fully-commented template ships as [`teleop_config.example.yaml`](teleop_config.example.yaml). Key parameters:
@@ -116,8 +112,6 @@ Behavior is customized via `teleop_config.yaml`; a fully-commented template ship
       # ... see teleop_config.example.yaml for the full set
 ```
 
----
-
 ## 🛠️ Development Setup
 
 For developers who want to modify source code or debug.
@@ -136,7 +130,10 @@ We provide a simplified Docker setup that communicates with Autoware via the Hos
 ./run_teleop.sh
 ```
 
-### 2. Build (Native ROS 2)
+### 2. Build (Keyboard Control Mode)
+
+#### Compilation
+
 ```bash
 mkdir -p autoware_manual_control_ws/src
 cd autoware_manual_control_ws/src
@@ -145,7 +142,72 @@ cd ..
 colcon build
 ```
 
----
+#### Run the Node
+
+```bash
+ros2 run autoware_manual_control keyboard_control
+```
+
+### 3. Build with Zenoh (Remote Driving)
+
+To enable the network transport (`zenoh_control`) for remote driving over Zenoh, you need the Zenoh C++ SDK and a JSON parser library.
+
+#### Prerequisites & Dependencies
+
+- **nlohmann_json**: A C++ JSON parser library. It can be installed via:
+  ```bash
+  sudo apt-get install nlohmann-json3-dev
+  ```
+- **Zenoh C/C++ SDK** (`zenohc` and `zenohcxx`):
+  - **Option A (Via rmw_zenoh workspace)**: If you build from a workspace that uses `rmw_zenoh`, the Zenoh vendor files are already bundled. You can export the path to this vendor prefix:
+    ```bash
+    export ZENOH_VENDOR_PREFIX="/path/to/rmw_zenoh_ws/install/zenoh_cpp_vendor/opt/zenoh_cpp_vendor"
+    export LD_LIBRARY_PATH="${ZENOH_VENDOR_PREFIX}/lib:${LD_LIBRARY_PATH:-}"
+    ```
+  - **Option B (System Installation)**: Refer to the [eclipse-zenoh/zenoh-cpp](https://github.com/eclipse-zenoh/zenoh-cpp) repository to build and install `zenohc` and `zenohcxx` to your system paths.
+
+#### Compilation
+
+Build the package with the `TELEOP_WITH_ZENOH` CMake flag:
+
+```bash
+mkdir -p autoware_manual_control_ws/src
+cd autoware_manual_control_ws/src
+git clone https://github.com/evshary/autoware_manual_control.git
+cd ..
+# Build Zenoh transport only
+colcon build --cmake-args -DTELEOP_WITH_KEYBOARD=OFF -DTELEOP_WITH_ZENOH=ON
+```
+
+#### Run the Node
+
+```bash
+ros2 run autoware_manual_control zenoh_control --ros-args --params-file teleop_config.yaml
+```
+
+#### Remote interface
+
+`zenoh_control` has no local keyboard — it is driven by a remote operator client over Zenoh. It subscribes operator intent on `manual_control/<vehicle>/intent` and publishes vehicle telemetry on `manual_control/<vehicle>/telemetry`; both payloads are JSON.
+
+Intent (client → node), one object per control tick:
+
+| Field | Type | Meaning |
+| :-- | :-- | :-- |
+| `throttle` / `brake` / `steer` | number | drive axes (the keyboard's `W` / `S` / `A`·`D`) |
+| `gear` | string | `PARK`, `DRIVE`, or `REVERSE` |
+| `mode_cycle` / `toggle_auto` / `reset_pose` | integer | monotonic counters — increment to trigger the `M` / `Z` / `R` actions (drop/duplicate-safe) |
+| `estop` | integer | non-zero = emergency stop |
+
+Telemetry (node → client), published every control tick:
+
+| Field | Meaning |
+| :-- | :-- |
+| `operation_mode` / `mode` / `mode_status` | AD-API operation mode, active drive mode, mode status text |
+| `velocity` / `steer_angle` / `gear` | live vehicle state |
+| `target_velocity` / `target_acceleration` / `target_steer` | the command being sent |
+| `shift_state` / `pending_gear` | gear-shift progress |
+| `info` | human-readable status / last error |
+| `timestamp` | publish time (ms) |
 
 ## 🏗️ Architecture
 
@@ -249,8 +311,6 @@ That is the whole change — one mode file, one register line, one config entry.
 ### CI/CD Pipeline
 *   **Triggers**: Push to `main` or Tag `v*` -> Builds & Pushes to GHCR.
 *   **Image**: `ghcr.io/evshary/autoware_manual_control:latest`
-
----
 
 ## ❓ Troubleshooting
 

--- a/src/io/intent/zenoh.hpp
+++ b/src/io/intent/zenoh.hpp
@@ -1,0 +1,199 @@
+#ifndef TELEOP_IO_INTENT_ZENOH_HPP
+#define TELEOP_IO_INTENT_ZENOH_HPP
+
+#include <zenoh.hxx>
+
+#include <nlohmann/json.hpp>
+
+#include "common/intent.hpp"
+#include "common/types.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <memory>
+#include <mutex>
+#include <string>
+
+namespace autoware::manual_control {
+
+struct ZenohIntentConfig {
+  std::string intent_key = "manual_control/v1/intent";
+  float arrival_timeout_s = 0.5f;
+};
+
+// Network IntentSource: decodes intent messages; deadman-brakes on stale input.
+class ZenohIntent {
+public:
+  ZenohIntent(std::shared_ptr<zenoh::Session> session,
+              const ZenohIntentConfig &cfg)
+      : cfg_(cfg), session_(std::move(session)) {
+    last_arrival_ = std::chrono::steady_clock::now();
+    subscriber_ = std::make_unique<zenoh::Subscriber<void>>(
+        session_->declare_subscriber(
+            zenoh::KeyExpr(cfg_.intent_key),
+            [this](zenoh::Sample &sample) { on_intent(sample); }, []() {}));
+  }
+
+  Intent update() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto now = std::chrono::steady_clock::now();
+
+    const bool fresh =
+        have_intent_ && secs(now - last_arrival_) <= cfg_.arrival_timeout_s;
+    watchdog_tripped_.store(!fresh);
+
+    if (!fresh)
+      return safe_state();
+
+    Intent s;
+    s.throttle = clamp01(latest_.throttle);
+    s.throttle_hold = s.throttle > 0.0f;
+    s.brake = clamp01(latest_.brake);
+    s.brake_hold = s.brake > 0.0f;
+    s.steer_dir = (latest_.steer > 0.0) ? 1 : (latest_.steer < 0.0 ? -1 : 0);
+
+    if (latest_.gear != applied_gear_) {
+      s.shift_drive = (latest_.gear == Gear::DRIVE);
+      s.shift_reverse = (latest_.gear == Gear::REVERSE);
+      s.shift_park = (latest_.gear == Gear::PARK);
+      applied_gear_ = latest_.gear;
+    }
+
+    s.emergency_stop = step(applied_estop_, latest_.estop);
+    s.switch_mode = step(applied_mode_cycle_, latest_.mode_cycle);
+    s.toggle_auto = step(applied_toggle_auto_, latest_.toggle_auto);
+    s.reset_pose = step(applied_reset_pose_, latest_.reset_pose);
+    return s;
+  }
+
+  std::string active_client_id() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return latest_.client_id;
+  }
+  bool watchdog_tripped() const { return watchdog_tripped_.load(); }
+
+private:
+  struct Wire {
+    float throttle = 0.0f;
+    float brake = 0.0f;
+    double steer = 0.0;
+    Gear gear = Gear::PARK;
+    int64_t estop = 0;
+    int64_t mode_cycle = 0;
+    int64_t toggle_auto = 0;
+    int64_t reset_pose = 0;
+    std::string client_id;
+  };
+
+  void on_intent(zenoh::Sample &sample) {
+    nlohmann::json j;
+    try {
+      j = nlohmann::json::parse(sample.get_payload().as_string());
+    } catch (...) {
+      warn_once("unparseable JSON");
+      return;
+    }
+
+    if (!j.contains("client_id") || !j["client_id"].is_string()) {
+      warn_once("missing or invalid client_id");
+      return;
+    }
+    auto num_ok = [&](const char *k) {
+      return !j.contains(k) || j[k].is_number();
+    };
+    if (!num_ok("throttle") || !num_ok("brake") || !num_ok("steer") ||
+        !num_ok("estop") || !num_ok("mode_cycle") || !num_ok("toggle_auto") ||
+        !num_ok("reset_pose")) {
+      warn_once("non-numeric value in numeric field");
+      return;
+    }
+    if (j.contains("gear")) {
+      if (!j["gear"].is_string()) {
+        warn_once("non-string gear");
+        return;
+      }
+      const std::string &g = j["gear"].get_ref<const std::string &>();
+      if (g != "DRIVE" && g != "REVERSE" && g != "PARK") {
+        warn_once("unknown gear value");
+        return;
+      }
+    }
+
+    Wire in;
+    in.throttle = j.value("throttle", 0.0);
+    in.brake = j.value("brake", 0.0);
+    in.steer = j.value("steer", 0.0);
+    in.gear = gear_from(j.value("gear", std::string("PARK")));
+    in.estop = j.value("estop", int64_t{0});
+    in.mode_cycle = j.value("mode_cycle", int64_t{0});
+    in.toggle_auto = j.value("toggle_auto", int64_t{0});
+    in.reset_pose = j.value("reset_pose", int64_t{0});
+    in.client_id = j.value("client_id", std::string{});
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    latest_ = in;
+    have_intent_ = true;
+    last_arrival_ = std::chrono::steady_clock::now();
+  }
+
+  static void warn_once(const char *reason) {
+    static bool warned = false;
+    if (!warned) {
+      warned = true;
+      std::fprintf(stderr,
+                   "[ZenohIntent] rejecting malformed intent (%s); "
+                   "will not warn again\n",
+                   reason);
+    }
+  }
+
+  static float secs(std::chrono::steady_clock::duration d) {
+    return std::chrono::duration<float>(d).count();
+  }
+  static float clamp01(float v) {
+    return v < 0.0f ? 0.0f : (v > 1.0f ? 1.0f : v);
+  }
+  static Gear gear_from(const std::string &g) {
+    if (g == "DRIVE")
+      return Gear::DRIVE;
+    if (g == "REVERSE")
+      return Gear::REVERSE;
+    return Gear::PARK;
+  }
+  // Monotonic one-shot counter edge-detector: true when `wire` rises above
+  // `applied` (which it then adopts). Adopting even a lower `wire` re-baselines
+  // a reconnected operator whose counter restarted, instead of stalling forever.
+  static bool step(int64_t &applied, int64_t wire) {
+    bool fired = wire > applied;
+    applied = wire;
+    return fired;
+  }
+  static Intent safe_state() {
+    Intent s;
+    s.brake = 1.0f;
+    return s;
+  }
+
+  ZenohIntentConfig cfg_;
+  std::shared_ptr<zenoh::Session> session_;
+  std::unique_ptr<zenoh::Subscriber<void>> subscriber_;
+
+  mutable std::mutex mutex_;
+  Wire latest_;
+  bool have_intent_ = false;
+  std::chrono::steady_clock::time_point last_arrival_;
+
+  Gear applied_gear_ = Gear::PARK;
+  int64_t applied_estop_ = 0;
+  int64_t applied_mode_cycle_ = 0;
+  int64_t applied_toggle_auto_ = 0;
+  int64_t applied_reset_pose_ = 0;
+
+  std::atomic<bool> watchdog_tripped_{true};
+};
+
+} // namespace autoware::manual_control
+
+#endif // TELEOP_IO_INTENT_ZENOH_HPP

--- a/src/io/intent/zenoh.hpp
+++ b/src/io/intent/zenoh.hpp
@@ -68,10 +68,6 @@ public:
     return s;
   }
 
-  std::string active_client_id() const {
-    std::lock_guard<std::mutex> lock(mutex_);
-    return latest_.client_id;
-  }
   bool watchdog_tripped() const { return watchdog_tripped_.load(); }
 
 private:
@@ -84,7 +80,6 @@ private:
     int64_t mode_cycle = 0;
     int64_t toggle_auto = 0;
     int64_t reset_pose = 0;
-    std::string client_id;
   };
 
   void on_intent(zenoh::Sample &sample) {
@@ -96,10 +91,6 @@ private:
       return;
     }
 
-    if (!j.contains("client_id") || !j["client_id"].is_string()) {
-      warn_once("missing or invalid client_id");
-      return;
-    }
     auto num_ok = [&](const char *k) {
       return !j.contains(k) || j[k].is_number();
     };
@@ -130,7 +121,6 @@ private:
     in.mode_cycle = j.value("mode_cycle", int64_t{0});
     in.toggle_auto = j.value("toggle_auto", int64_t{0});
     in.reset_pose = j.value("reset_pose", int64_t{0});
-    in.client_id = j.value("client_id", std::string{});
 
     std::lock_guard<std::mutex> lock(mutex_);
     latest_ = in;

--- a/src/io/telemetry/zenoh.hpp
+++ b/src/io/telemetry/zenoh.hpp
@@ -1,0 +1,93 @@
+#ifndef TELEOP_IO_TELEMETRY_ZENOH_HPP
+#define TELEOP_IO_TELEMETRY_ZENOH_HPP
+
+#include <zenoh.hxx>
+
+#include <nlohmann/json.hpp>
+
+#include "common/telemetry.hpp"
+#include "common/types.hpp"
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace autoware::manual_control {
+
+// Network TelemetrySink: serializes each Telemetry to JSON on the telemetry key.
+class ZenohTelemetry {
+public:
+  ZenohTelemetry(std::shared_ptr<zenoh::Session> session,
+                 const std::string &telemetry_key)
+      : session_(std::move(session)) {
+    pub_ = std::make_unique<zenoh::Publisher>(
+        session_->declare_publisher(telemetry_key));
+  }
+
+  // Injects extra JSON fields at publish time (source-derived, wired at the root).
+  void set_aux(std::function<void(nlohmann::json &)> f) { aux_ = std::move(f); }
+
+  void publish(const Telemetry &t) {
+    nlohmann::json j;
+    j["mode"] = t.mode;
+    j["mode_status"] = t.mode_status;
+    j["operation_mode"] = t.operation_mode;
+    j["velocity"] = t.vehicle.velocity;
+    j["gear"] = gear_str(t.vehicle.gear);
+    j["steer_angle"] = t.vehicle.steer_angle;
+    j["target_velocity"] = t.command.velocity;
+    j["target_acceleration"] = t.command.acceleration;
+    j["target_steer"] = t.command.steer_angle;
+    j["shift_state"] = shift_state_str(t.shift_state);
+    j["pending_gear"] =
+        (t.shift_state != ShiftState::IDLE) ? gear_str(t.pending_gear) : "";
+    j["info"] = t.info;
+    if (aux_)
+      aux_(j);
+    j["timestamp"] = std::chrono::duration_cast<std::chrono::milliseconds>(
+                         std::chrono::system_clock::now().time_since_epoch())
+                         .count();
+    try {
+      pub_->put(zenoh::Bytes(j.dump()));
+    } catch (...) {
+    }
+  }
+
+private:
+  static std::string gear_str(Gear g) {
+    switch (g) {
+    case Gear::DRIVE:
+      return "DRIVE";
+    case Gear::REVERSE:
+      return "REVERSE";
+    case Gear::PARK:
+      return "PARK";
+    case Gear::LOW:
+      return "LOW";
+    case Gear::NEUTRAL:
+      return "NEUTRAL";
+    default:
+      return "NONE";
+    }
+  }
+  static std::string shift_state_str(ShiftState s) {
+    switch (s) {
+    case ShiftState::STOPPING:
+      return "STOPPING";
+    case ShiftState::SHIFTING:
+      return "SHIFTING";
+    default:
+      return "IDLE";
+    }
+  }
+
+  std::shared_ptr<zenoh::Session> session_;
+  std::unique_ptr<zenoh::Publisher> pub_;
+  std::function<void(nlohmann::json &)> aux_;
+};
+
+} // namespace autoware::manual_control
+
+#endif // TELEOP_IO_TELEMETRY_ZENOH_HPP

--- a/src/zenoh_control.cpp
+++ b/src/zenoh_control.cpp
@@ -29,8 +29,8 @@ int main(int argc, char *argv[]) {
 
   const std::string zenoh_cfg =
       load_param<std::string>(*node, "zenoh_config", std::string{});
-  const std::string vehicle =
-      load_param<std::string>(*node, "vehicle", std::string{"v1"});
+  const std::string scope =
+      load_param<std::string>(*node, "scope", std::string{"v1"});
   const float arrival_timeout_ms =
       load_float(*node, "arrival_timeout_ms", 500.0f);
 
@@ -41,19 +41,19 @@ int main(int argc, char *argv[]) {
       std::make_shared<zenoh::Session>(zenoh::Session::open(std::move(zconf)));
 
   ZenohIntentConfig in_cfg;
-  in_cfg.intent_key = "manual_control/" + vehicle + "/intent";
+  in_cfg.intent_key = "manual_control/" + scope + "/intent";
   in_cfg.arrival_timeout_s = arrival_timeout_ms / 1000.0f;
   ZenohIntent intent(session, in_cfg);
 
-  ZenohTelemetry telemetry(session, "manual_control/" + vehicle + "/telemetry");
+  ZenohTelemetry telemetry(session, "manual_control/" + scope + "/telemetry");
   telemetry.set_aux([&intent](nlohmann::json &j) {
     j["watchdog_tripped"] = intent.watchdog_tripped();
   });
 
   RuntimeConfig cfg = RuntimeConfig::load(*node);
 
-  std::fprintf(stderr, "[zenoh_control] vehicle=%s rate=%.0fHz intent=%s\n",
-               vehicle.c_str(), cfg.rate_hz, in_cfg.intent_key.c_str());
+  std::fprintf(stderr, "[zenoh_control] scope=%s rate=%.0fHz intent=%s\n",
+               scope.c_str(), cfg.rate_hz, in_cfg.intent_key.c_str());
 
   // No startup pose seed: seeding would teleport the vehicle and break self-localization.
   run_control_runtime(node, intent, telemetry, cfg);

--- a/src/zenoh_control.cpp
+++ b/src/zenoh_control.cpp
@@ -47,7 +47,6 @@ int main(int argc, char *argv[]) {
 
   ZenohTelemetry telemetry(session, "manual_control/" + vehicle + "/telemetry");
   telemetry.set_aux([&intent](nlohmann::json &j) {
-    j["active_client_id"] = intent.active_client_id();
     j["watchdog_tripped"] = intent.watchdog_tripped();
   });
 

--- a/src/zenoh_control.cpp
+++ b/src/zenoh_control.cpp
@@ -1,0 +1,64 @@
+// Zenoh-driven teleop entry point.
+
+#include <cstdio>
+#include <memory>
+#include <string>
+
+// zenoh.hxx must precede rclcpp to avoid macro/template clashes.
+#include <zenoh.hxx>
+
+#include <nlohmann/json.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include "core/control_runtime.hpp"
+#include "core/drive_mode_factory.hpp"
+#include "core/param_utils.hpp"
+#include "core/register_modes.hpp"
+#include "io/intent/zenoh.hpp"
+#include "io/telemetry/zenoh.hpp"
+#include "ros/manual_control_node.hpp"
+
+using namespace autoware::manual_control;
+
+int main(int argc, char *argv[]) {
+  rclcpp::init(argc, argv);
+
+  auto node = std::make_shared<ManualControlNode>();
+  register_all_modes(DriveModeFactory::instance(), *node);
+  activate_modes_from_config(DriveModeFactory::instance(), *node);
+
+  const std::string zenoh_cfg =
+      load_param<std::string>(*node, "zenoh_config", std::string{});
+  const std::string vehicle =
+      load_param<std::string>(*node, "vehicle", std::string{"v1"});
+  const float arrival_timeout_ms =
+      load_float(*node, "arrival_timeout_ms", 500.0f);
+
+  zenoh::Config zconf = zenoh_cfg.empty()
+                            ? zenoh::Config::create_default()
+                            : zenoh::Config::from_file(zenoh_cfg.c_str());
+  auto session =
+      std::make_shared<zenoh::Session>(zenoh::Session::open(std::move(zconf)));
+
+  ZenohIntentConfig in_cfg;
+  in_cfg.intent_key = "manual_control/" + vehicle + "/intent";
+  in_cfg.arrival_timeout_s = arrival_timeout_ms / 1000.0f;
+  ZenohIntent intent(session, in_cfg);
+
+  ZenohTelemetry telemetry(session, "manual_control/" + vehicle + "/telemetry");
+  telemetry.set_aux([&intent](nlohmann::json &j) {
+    j["active_client_id"] = intent.active_client_id();
+    j["watchdog_tripped"] = intent.watchdog_tripped();
+  });
+
+  RuntimeConfig cfg = RuntimeConfig::load(*node);
+
+  std::fprintf(stderr, "[zenoh_control] vehicle=%s rate=%.0fHz intent=%s\n",
+               vehicle.c_str(), cfg.rate_hz, in_cfg.intent_key.c_str());
+
+  // No startup pose seed: seeding would teleport the vehicle and break self-localization.
+  run_control_runtime(node, intent, telemetry, cfg);
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/teleop_config.example.yaml
+++ b/teleop_config.example.yaml
@@ -5,7 +5,7 @@
     operator_mode: remote
 
     # zenoh_control only
-    vehicle: v1
+    scope: v1
     arrival_timeout_ms: 500.0
     zenoh_config: ""           # zenoh config json5 path; empty = default
 

--- a/teleop_config.example.yaml
+++ b/teleop_config.example.yaml
@@ -4,6 +4,11 @@
     # implicit idle/safe state; entering the drive mode self-engages.
     operator_mode: remote
 
+    # zenoh_control only
+    vehicle: v1
+    arrival_timeout_ms: 500.0
+    zenoh_config: ""           # zenoh config json5 path; empty = default
+
     init_pose:
       presets:
         names: ["origin", "intersection"]


### PR DESCRIPTION
## Summary
Adds a network transport so a remote operator can drive the vehicle over Zenoh — sending `Intent` and receiving `Telemetry` as JSON — alongside the existing local keyboard transport. The teleop <-> Autoware path is unchanged (pure ROS/AD-API). This is the second implementation of the two-port IO layer introduced in #10, so the shared control core (drive modes, AD-API engage, the ROS adapter) is reused untouched.

## Motivation
#10 split control into two swappable ports — an `IntentSource` (produces an `Intent` each tick) and a `TelemetrySink` (consumes a `Telemetry` each tick) — with the keyboard as the only implementation. Driving from somewhere other than the local terminal then only needs a second pair of port implementations, not changes to the control loop. This PR provides that pair for the network case, and a sibling entry point that wires them up.

## What's in this PR (2 commits)
- `feat(io): zenoh intent source and telemetry sink` — `ZenohIntent` subscribes to an intent key, validates + decodes each JSON message into an `Intent`, and deadman-brakes (returns a full-brake safe state) when messages stop arriving within `arrival_timeout_s`. `ZenohTelemetry` serializes each `Telemetry` to JSON on a telemetry key, with a `set_aux` hook to inject source-derived fields at publish time.
- `feat: zenoh_control entry point` — a sibling to `keyboard_control`: opens a Zenoh session, constructs `ZenohIntent` + `ZenohTelemetry`, and hands them to the same `run_control_runtime`. Adds the CMake options `TELEOP_WITH_KEYBOARD` (ON by default) and `TELEOP_WITH_ZENOH` (OFF by default) so the standalone/upstream build stays Zenoh-free; `ZENOH=ON` pulls in `zenohcxx`/`nlohmann_json`. Params: `vehicle`, `arrival_timeout_ms`, `zenoh_config`.

## Design notes
- Transport = compile-time sibling entry points, not a runtime selector. `zenoh_control.cpp` sits beside `keyboard_control.cpp`; each is named by its transport and gated by its own CMake toggle.
- Wire contract. Keys `manual_control/<vehicle>/{intent,telemetry}`; both payloads are JSON. Continuous controls (throttle, brake, steer) are levels. Discrete one-shot actions (emergency stop, drive-mode cycle, operation-mode toggle, reset pose) travel as monotonically-increasing counters and are edge-detected by a small `step()` helper: it fires once per increase and always adopts the latest value, which makes it drop/dup-safe over lossy pub/sub and lets a reconnecting operator (whose counter restarts) re-baseline instead of stalling.
- Deadman by construction. `ZenohIntent::update()` returns a full-brake `Intent` whenever the last arrival is older than `arrival_timeout_s`, so a dropped connection fails safe without any explicit reset on the sender side.
- Sink/source decoupling via `set_aux`. The entry point (composition root) injects source-derived fields — the active operator id and watchdog state — into the telemetry JSON through `set_aux`, so `ZenohTelemetry::publish(const Telemetry&)` stays Telemetry-only and the sink never depends on the source.

## Testing
Both build profiles compile cleanly: the default (keyboard only, no Zenoh) and `-DTELEOP_WITH_KEYBOARD=OFF -DTELEOP_WITH_ZENOH=ON` (Zenoh only). Validated end-to-end against a running Autoware vehicle over the Zenoh transport: a remote operator engaged, cycled drive mode, shifted gear, applied throttle and drove, and reset pose — with all telemetry fields (mode, operation mode, velocity, gear, steering, targets, shift state, active operator id, watchdog) round-tripping back; the deadman safe-state was verified by stopping the intent stream.