### PR TITLE
ci(book): deploy the mdBook to gh-pages

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -19,9 +19,9 @@ jobs:
       - name: Install mdbook + mdbook-mermaid
         run: |
           mkdir -p "$HOME/.local/bin"
-          curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.40/mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz \
+          curl -fsSL https://github.com/rust-lang/mdBook/releases/download/v0.4.40/mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz \
             | tar -xz -C "$HOME/.local/bin"
-          curl -sSL https://github.com/badboy/mdbook-mermaid/releases/download/v0.14.0/mdbook-mermaid-v0.14.0-x86_64-unknown-linux-gnu.tar.gz \
+          curl -fsSL https://github.com/badboy/mdbook-mermaid/releases/download/v0.14.0/mdbook-mermaid-v0.14.0-x86_64-unknown-linux-gnu.tar.gz \
             | tar -xz -C "$HOME/.local/bin"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,0 +1,35 @@
+name: Book
+
+on:
+  push:
+    branches: [ "main" ]
+    paths: [ "book/**", ".github/workflows/book.yml" ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Prebuilt binaries: cargo-installing either tool costs minutes per run.
+      - name: Install mdbook + mdbook-mermaid
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.40/mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz \
+            | tar -xz -C "$HOME/.local/bin"
+          curl -sSL https://github.com/badboy/mdbook-mermaid/releases/download/v0.14.0/mdbook-mermaid-v0.14.0-x86_64-unknown-linux-gnu.tar.gz \
+            | tar -xz -C "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Build
+        run: mdbook build book
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: book/book

--- a/book/src/architecture.md
+++ b/book/src/architecture.md
@@ -78,7 +78,7 @@ The control loop, the modes and every I/O are reused unchanged. The `native_zeno
 
 Drive modes are a strategy pattern behind `DriveModeFactory`. The smallest worked example is `src/modes/stop_mode.hpp` (~40 lines) — read it first. To add one:
 
-1. **Implement** `src/modes/<name>_mode.hpp`: a class inheriting `DriveMode` (`src/core/drive_mode.hpp`) with `static constexpr const char* kName = "<name>";`, a `struct Params` plus `static Params loadParams(const ParameterReader&)` reading its tuning via `reader.read<T>(...)`, a constructor taking `const Params&`, and `ControlCommand update(float dt, const Intent&, const VehicleState&)` (optionally `onEnter` / `onExit` / `getStatusString`).
+1. **Implement** `src/modes/<name>_mode.hpp`: a class inheriting `DriveMode` (`src/core/drive_mode.hpp`) with `static constexpr const char* kName = "<name>";`, a `struct Params` plus `static Params loadParams(const ParameterReader&)` reading its tuning via `reader.read<T>(...)`, a constructor taking `const Params&`, `getName()` (return `kName`), and `ControlCommand update(float dt, const Intent&, const VehicleState&)` (optionally `onEnter` / `onExit` / `getStatusString`).
 2. **Register** it: one line `register_mode<YourDriveMode>(factory, reader);` in `register_all_modes` (`src/core/register_modes.hpp`).
 3. **Enable** it: add its `kName` to the `modes:` list in your config (and a tuning block if it has params).
 

--- a/book/src/building.md
+++ b/book/src/building.md
@@ -27,7 +27,7 @@ Getting the Zenoh SDK:
 
 ## The ROS-free build (`native_zenoh`)
 
-With `TELEOP_AUTOWARE_TRANSPORT=native_zenoh`, `ament_cmake` is optional and skipped when absent (`CMakeLists.txt`): the package builds as a plain CMake project. The dependencies are only the Zenoh SDK, `nlohmann_json`, a system `libyaml` (linked **static**, so no `libyaml.so` joins the runtime), and Fast-CDR — which CMake fetches itself (`FetchContent`, pinned `v1.1.1`, built static + PIC and folded into the binary). No ROS, no message packages, no rosidl tooling.
+With `TELEOP_AUTOWARE_TRANSPORT=native_zenoh`, `ament_cmake` is optional and skipped when absent (`CMakeLists.txt`): the package builds as a plain CMake project. The dependencies are only the Zenoh SDK, `nlohmann_json`, a system `libyaml` (linked **static**, so no `libyaml.so` joins the runtime), and Fast-CDR — which CMake fetches itself (`FetchContent`, pinned `v1.1.1`, built static + PIC and folded into the binary). No ROS, no message packages, no rosidl tooling. Configure from a shell that has **not** sourced ROS: a sourced environment makes CMake find `ament_cmake` and take the ament path instead.
 
 ```bash
 cmake -S . -B build \
@@ -35,7 +35,7 @@ cmake -S . -B build \
   -DTELEOP_WITH_ZENOH=ON -DTELEOP_WITH_KEYBOARD=OFF \
   -DZENOH_VENDOR_PREFIX=/path/to/zenoh   # omit if zenohc/zenohcxx are installed system-wide
 cmake --build build -j
-./build/zenoh_control --config config/teleop.yaml
+./build/zenoh_control --config config/teleop.example.yaml   # or your config/teleop.yaml copy
 ```
 
 The resulting binary links only `libzenohc`, the static Fast-CDR and the static libyaml, plus the C/C++ runtime — and its wire bytes are correct by construction: it runs the same `rosidl_typesupport_fastrtps_cpp` serialiser `rmw_fastrtps` uses (see [Autoware Transport](autoware-transport.md)). You can also build the local-terminal operator with no ROS by flipping the I/O flags (`-DTELEOP_WITH_KEYBOARD=ON -DTELEOP_WITH_ZENOH=OFF`); CMake then builds `keyboard_control` against the same ROS-free transport.
@@ -58,6 +58,6 @@ tools/vendor_idl.sh                 # rewrites src/transport/zenoh/generated/, t
 1. Builds the rosidl generators from the tiny `tools/regen` ament package (`tools/regen/CMakeLists.txt` lists the wire contract as `TELEOP_MSG_IDL`; `stage_idl.py` stages the installed `.idl` under this project's namespace so the generated types are namespaced correctly). `tools/COLCON_IGNORE` keeps this helper package out of the normal workspace build.
 2. Copies the generated `rosidl_generator_cpp` and `rosidl_typesupport_fastrtps_cpp` output into `src/transport/zenoh/generated/`.
 3. Computes the include closure of that generated code with `g++ -M` and vendors the external rosidl runtime headers it pulls in (`rosidl_runtime_c`, `rosidl_runtime_cpp`, `rosidl_typesupport_*`, `rmw`, `rcutils`).
-4. Writes the files and reports the counts — it does not `git add` them, so commit the result yourself.
+4. Reports the counts — it does not `git add` anything, so commit the result yourself.
 
 After regenerating, the CI golden-drift guard ([Testing & CI](testing.md)) confirms the new bytes still match a live rmw. CI flags when a regen is *due* by failing that same guard against the old committed bytes.

--- a/book/src/cross-machine.md
+++ b/book/src/cross-machine.md
@@ -26,7 +26,7 @@ ZENOH_CONNECT=tcp/<remote>:7447 ./run_containers.sh --operator up
 
 Autoware itself still speaks DDS. To put its topics on Zenoh, a [`zenoh-bridge-ros2dds`](https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds) runs *next to* Autoware, sharing its DDS domain, and serves Zenoh on TCP. The shipped compose stack runs `eclipse/zenoh-bridge-ros2dds:1.9.0` with `network_mode: host`, launched as `-n /v1 -c /config/zenoh-bridge.json5 -l tcp/0.0.0.0:7447` so every bridged key is prefixed with the `/v1` scope and the bridge listens on 7447. `config/zenoh-bridge.json5` is deliberately minimal: `mode: "peer"`, an empty `listen` (supplied by the launch command instead, so a connect-only bridge can simply drop it), and an **allow-list** under `plugins.ros2dds.allow` that is exactly the topics and services the node touches — nothing else crosses the bridge. On the wire it exposes `v1/vehicle/status/...` etc., which is exactly what the gateway's scope-prefixed keys address.
 
-For the NAT case (below) the bridge instead dials **out** to a router. `run_containers.sh` injects that: with `ZENOH_CONNECT` set it launches the bridge as `-e <endpoint> client` — connecting out, as a client, with no `-l` so it never contends for the port.
+For the NAT case (below) the bridge instead dials **out** to a router. `run_containers.sh` injects that: with `ZENOH_CONNECT` set it launches the bridge with `-e <endpoint>` and no `-l` (so it never contends for the port), and appends the `ZENOH_MODE` positional when that is set — `client` for a router, the peer default otherwise.
 
 ## No discovery: one explicit endpoint
 
@@ -80,7 +80,7 @@ A mesh VPN — [Tailscale](https://tailscale.com/), plain [WireGuard](https://ww
 
 When neither end has a reachable address, put a Zenoh router (`zenohd`) on a host both can reach — typically a small public VM — and have the operator **and** the vehicle each `connect` **out** to it. Both connections are outbound, so neither side needs a public IP or an inbound port; the router is the only publicly reachable component, which is what solves NAT.
 
-The router relays only between **clients**, not between two peers — so both ends join as clients. On the vehicle side `run_containers.sh` does this automatically (the injected bridge command ends in `client`); on the operator side, set `ZENOH_MODE=client`.
+The router relays only between **clients**, not between two peers — so both ends join as clients: set `ZENOH_MODE=client` on the vehicle side (it becomes the injected bridge command's mode positional) and on the operator side alike.
 
 ```mermaid
 flowchart LR
@@ -108,10 +108,10 @@ flowchart LR
 docker run --rm -p 7447:7447 eclipse/zenoh:1.9.0 -l tcp/0.0.0.0:7447
 ```
 
-**2. Vehicle host** — Autoware plus the bridge, the bridge dialing the router (the script makes it a client):
+**2. Vehicle host** — Autoware plus the bridge, the bridge dialing the router as a client:
 
 ```bash
-ZENOH_CONNECT=tcp/<router-ip>:7447 ./run_containers.sh up --transport zenoh
+ZENOH_CONNECT=tcp/<router-ip>:7447 ZENOH_MODE=client ./run_containers.sh up --transport zenoh
 ```
 
 **3. Operator host** — the minimal teleop, dialing the same router as a client:
@@ -128,4 +128,4 @@ The teleop now drives the vehicle through the router. `run_teleop.sh` runs `keyb
 Over the public Internet this link carries live vehicle control. It **MUST** be encrypted and authenticated end to end — an unauthenticated Zenoh endpoint on a public IP is an open door to the vehicle. Two layers apply:
 
 - **Transport security (required).** Zenoh natively supports TLS (optionally mutual TLS) and username/password auth. To turn it on, switch each endpoint's scheme from `tcp/…` to `tls/…` and add a `transport.link.tls` block (plus `transport.auth` for credentials) to the Zenoh config on **both** ends; `config/zenoh-client.example.json5` and `config/zenoh-bridge.json5` carry a one-line pointer back to this section for exactly that. Generating and distributing the certificates and credentials is the operator's responsibility, and is deliberately left to the deployment — but the link is not safe on the public Internet until it is done. (A VPN, above, satisfies this requirement at the network layer instead.)
-- **Deadman (already on).** Independently of the link, the control loop fails safe on latency or loss: if no fresh intent arrives within `arrival_timeout_ms` (default 500 ms), the node deadman-brakes until input resumes (see [Configuration](configuration.md#zenoh-keys)). A degraded or dropped link cannot leave the vehicle driving.
+- **Deadman (on the remote-I/O leg).** With `zenoh_control`, the control loop fails safe on latency or loss: if no fresh intent arrives within `arrival_timeout_ms` (default 500 ms), the node deadman-brakes until input resumes (see [Configuration](configuration.md#zenoh-keys)), so a degraded or dropped operator link cannot leave the vehicle driving. The shipped `--operator` flow runs `keyboard_control`, whose intent is local — there the timeout only bounds the AD-API service calls, and link security is what protects the Autoware-transport leg.

--- a/book/src/running-locally.md
+++ b/book/src/running-locally.md
@@ -1,6 +1,6 @@
 # Running Locally
 
-`run_containers.sh` brings up the whole stack **built from this checkout** on one machine: Autoware, the teleop node compiled from source, and — on the Zenoh transport — the DDS↔Zenoh bridge. It is the development counterpart to the prebuilt release image: where the Quickstart's `docker-compose-release.yaml` pulls a published `autoware:universe`-based teleop image, this stack uses `docker-compose.yaml`, which builds the teleop service locally (`build: .`) from the working tree. That tree is also bind-mounted into the container, so `run_teleop.sh` recompiles against your edits on each attach.
+`run_containers.sh` brings up the whole stack **built from this checkout** on one machine: Autoware, the teleop node compiled from source, and — on the Zenoh transport — the DDS↔Zenoh bridge. It is the development counterpart to the prebuilt release image: where the README Quickstart's `docker-compose-release.yaml` pulls a published image carrying the Autoware runtime, this stack uses `docker-compose.yaml`, which builds the teleop service locally (`build: .`) from the working tree. That tree is also bind-mounted into the container, so `run_teleop.sh` recompiles against your edits on each attach.
 
 ## Bringing the stack up
 

--- a/book/src/testing.md
+++ b/book/src/testing.md
@@ -30,7 +30,7 @@ ctest --test-dir build --output-on-failure
 
 ### `test_param_reader` — the native parameter reader
 
-10 tests pinning the `native_zenoh` reader's contract: dotted nested keys, inline string and float sequences, type-mismatch fallback, empty-string-as-default, quoting and trailing-comment semantics, independent sibling sections, and the missing-file all-defaults case.
+12 tests pinning the `native_zenoh` reader's contract: dotted nested keys, inline string and float sequences, type-mismatch fallback, empty-string-as-default, present-but-empty sequences, quoting and trailing-comment semantics, independent sibling sections, the `ros__parameters` envelope unwrap, and the missing-file all-defaults case.
 
 ## CI
 
@@ -55,7 +55,7 @@ ROS is needed in exactly one place: confirming the *committed goldens still matc
 RMW_IMPLEMENTATION=rmw_cyclonedds_cpp python3 test/capture_golden.py --check
 ```
 
-`test/capture_golden.py` is a separate refresh/drift tool, **not** part of `colcon test`. It re-serialises every production and test-corpus message through `rclpy` under `rmw_cyclonedds_cpp` — i.e. the live DDS-CDR wire — and `--check` diffs that against the committed goldens. A drifted Autoware message therefore turns CI red and prompts a re-vendor (`tools/vendor_idl.sh`, see [Building](building.md#regenerating-the-codec)). With no flag, the same script *rewrites* the goldens.
+`test/capture_golden.py` is a separate refresh/drift tool, **not** part of `colcon test`. It re-serialises every production and test-corpus message through `rclpy` under `rmw_cyclonedds_cpp` — i.e. the live DDS-CDR wire — and `--check` diffs that against the committed goldens. A drifted Autoware message therefore turns CI red and prompts a re-vendor (`tools/vendor_idl.sh`, see [Building](building.md#regenerating-the-codec)). With no flag, the same script prints the freshly captured bytes for pasting into `test_cdr.cpp`'s `GOLDEN(...)` literals.
 
 Together the two jobs close the loop: `build-rosfree` proves the shipped binary carries the codec with no ROS, and `golden-drift` proves that codec still equals the real wire.
 

--- a/src/transport/zenoh/cli_params.hpp
+++ b/src/transport/zenoh/cli_params.hpp
@@ -10,10 +10,10 @@ namespace autoware::manual_control::zenoh_params
 {
 
 // Immutable view of the parameters resolved at startup: the contents of the
-// `--config <yaml>` file, a plain nested YAML document, flattened to dotted
-// names (physics: { max_speed: x } -> "physics.max_speed"). A scalar is a
-// one-element vector; a sequence keeps its elements. No ROS conventions: no
-// node/parameter envelope to strip, no env overlay -- a pure load-time lookup.
+// `--config <yaml>` file (a ROS 2 params envelope is unwrapped, plain nested
+// YAML taken as-is), flattened to dotted names (physics: { max_speed: x } ->
+// "physics.max_speed"). A scalar is a one-element vector; a sequence keeps
+// its elements. No env overlay -- a pure load-time lookup.
 class ParamMap
 {
 public:


### PR DESCRIPTION
This adds a `Book` workflow: pushes to `main` that touch `book/**` build the book with pinned prebuilt binaries (mdbook v0.4.40 + mdbook-mermaid v0.14.0, no cargo install) and publish `book/book` to the `gh-pages` branch via `peaceiris/actions-gh-pages` using only the default `GITHUB_TOKEN`; `workflow_dispatch` allows a manual run.

Validation: the exact pinned toolchain builds the book in a clean container; the deploy was rehearsed end to end on a fork (gh-pages produced, Pages renders including mermaid); every page's commands were re-run/re-check against this branch.